### PR TITLE
fix: Absolute readme image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## About Open.IdentityServer
 
-![Open.IdentityServer](./docs/images/OpenIdentityServerDark.png)
+![Open.IdentityServer](https://raw.githubusercontent.com/RockSolidKnowledge/Open.IdentityServer/main/docs/images/OpenIdentityServerDark.png)
 
 Open.IdentityServer is a free, open source [OpenID Connect](http://openid.net/connect/) and [OAuth 2.0](https://tools.ietf.org/html/rfc6749) framework for .NET.
 


### PR DESCRIPTION
Changes the image link to be absolute so that the when the readme is rendered on nuget.org, the image is present.