### PR TITLE
feat: implement storage of session in database

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -5,7 +5,7 @@
         <ExtensionsVersion>10.0.5</ExtensionsVersion>
         <EntityFrameworkVersion>10.0.10</EntityFrameworkVersion>
 
-        <IdentityServerVersion>2.0.0-*</IdentityServerVersion>
+        <IdentityServerVersion>2.1.0-*</IdentityServerVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -61,7 +61,8 @@
         <PackageReference Update="Microsoft.EntityFrameworkCore.Design" Version="$(EntityFrameworkVersion)" PrivateAssets="All"/>
         
         <!--other entity framework-->
-        <PackageReference Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
+        <PackageReference Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+        <PackageReference Update="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8" />
         <PackageReference Update="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     </ItemGroup>
 

--- a/src/EntityFramework.Storage/src/Mappers/IdentityServerServerSideSessionsExtensions.cs
+++ b/src/EntityFramework.Storage/src/Mappers/IdentityServerServerSideSessionsExtensions.cs
@@ -1,0 +1,83 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+#nullable enable
+
+namespace Open.IdentityServer.EntityFramework.Mappers;
+
+/// <summary>
+/// Mapping extension methods for IdentityServerServerSideSessions objects
+/// </summary>
+public static class IdentityServerServerSideSessionsExtensions
+{
+    /// <summary>
+    /// Mapping extension methods for <see cref="Entities.IdentityServerServerSideSessions"/>
+    /// </summary>
+    /// <param name="sessionEntity">The entity.</param>
+    extension(Entities.IdentityServerServerSideSessions sessionEntity)
+    {
+        /// <summary>
+        /// Mapper for <see cref="Entities.IdentityServerServerSideSessions"/> to convert into an instance of <see cref="Models.IdentityServerServerSideSessions"/>
+        /// </summary>
+        /// <returns>mapped instance of <see cref="Models.IdentityServerServerSideSessions"/></returns>
+        public Models.IdentityServerServerSideSessions ToModel()
+        {
+            return new Models.IdentityServerServerSideSessions
+            {
+                Key = sessionEntity.Key,
+                Scheme = sessionEntity.Scheme,
+                SubjectId = sessionEntity.SubjectId,
+                SessionId = sessionEntity.SessionId,
+                DisplayName = sessionEntity.DisplayName,
+                Created = sessionEntity.Created,
+                Renewed = sessionEntity.Renewed,
+                Expires = sessionEntity.Expires,
+                Data = sessionEntity.Data
+            };
+        }
+    }
+    
+    /// <summary>
+    /// Mapping extension methods for <see cref="Models.IdentityServerServerSideSessions"/>
+    /// </summary>
+    /// <param name="sessionModel">The model.</param>
+    extension(Models.IdentityServerServerSideSessions sessionModel)
+    {
+        /// <summary>
+        /// Mapper for <see cref="Models.IdentityServerServerSideSessions"/> to convert into an instance of <see cref="Entities.IdentityServerServerSideSessions"/>
+        /// </summary>
+        /// <returns>mapped instance of <see cref="Entities.IdentityServerServerSideSessions"/></returns>
+        public Entities.IdentityServerServerSideSessions ToEntity()
+        {
+            return new Entities.IdentityServerServerSideSessions
+            {
+                Key = sessionModel.Key,
+                Scheme = sessionModel.Scheme,
+                SubjectId = sessionModel.SubjectId,
+                SessionId = sessionModel.SessionId,
+                DisplayName = sessionModel.DisplayName,
+                Created = sessionModel.Created,
+                Renewed = sessionModel.Renewed,
+                Expires = sessionModel.Expires,
+                Data = sessionModel.Data
+            };
+        }
+        
+        /// <summary>
+        /// Updates <see cref="Entities.IdentityServerServerSideSessions"/> with instance of <see cref="Models.IdentityServerServerSideSessions"/>
+        /// </summary>
+        /// <param name="existingEntity">The entity.</param>
+        public void UpdateEntity(Entities.IdentityServerServerSideSessions existingEntity)
+        {
+            existingEntity.Key = sessionModel.Key;
+            existingEntity.Scheme = sessionModel.Scheme;
+            existingEntity.SubjectId = sessionModel.SubjectId;
+            existingEntity.SessionId = sessionModel.SessionId;
+            existingEntity.DisplayName = sessionModel.DisplayName;
+            existingEntity.Created = sessionModel.Created;
+            existingEntity.Renewed = sessionModel.Renewed;
+            existingEntity.Expires = sessionModel.Expires;
+            existingEntity.Data = sessionModel.Data;
+        }
+    }
+}

--- a/src/EntityFramework.Storage/src/Stores/Compatibility/IdentityServerServerSideSessionStore.cs
+++ b/src/EntityFramework.Storage/src/Stores/Compatibility/IdentityServerServerSideSessionStore.cs
@@ -1,0 +1,115 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Open.IdentityServer.EntityFramework.Interfaces;
+using Open.IdentityServer.EntityFramework.Mappers;
+using Open.IdentityServer.Stores;
+using IdentityServerServerSideSessions = Open.IdentityServer.Models.IdentityServerServerSideSessions;
+
+namespace Open.IdentityServer.EntityFramework.Stores;
+
+/// <summary>
+/// Storage and retrieval of server side sessions using entity framework core
+/// </summary>
+public class IdentityServerServerSideSessionStore(
+    IPersistedGrantDbContext dbContext,
+    ILogger<IdentityServerServerSideSessionStore> logger): IIdentityServerServerSideSessionStore
+{
+    /// <inheritdoc />
+    public async Task<IdentityServerServerSideSessions?> GetSession(string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        Entities.IdentityServerServerSideSessions? session = await dbContext.ServerSideSessions
+            .SingleOrDefaultAsync(x => x.Key == key);
+        
+        return session?.ToModel();
+    }
+
+    /// <inheritdoc />
+    public async Task CreateSession(IdentityServerServerSideSessions session)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(session.Key);
+        
+        Entities.IdentityServerServerSideSessions? existing = await dbContext.ServerSideSessions
+            .SingleOrDefaultAsync(x => x.Key == session.Key);
+        
+        if (existing != null)
+        {
+            logger.LogError("failed storing '{SessionKey}' session in database, session with key already exists", session.Key);
+            return;
+        }
+
+        Entities.IdentityServerServerSideSessions sessionEntity = session.ToEntity();
+
+        await dbContext.ServerSideSessions.AddAsync(sessionEntity);
+
+        try
+        {
+            await dbContext.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "exception storing '{SessionKey}' session in database", session.Key);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task UpdateSession(IdentityServerServerSideSessions session)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(session.Key);
+        
+        Entities.IdentityServerServerSideSessions? existing = await dbContext.ServerSideSessions
+            .SingleOrDefaultAsync(x => x.Key == session.Key);
+
+        if (existing == null)
+        {
+            logger.LogError("failed updating '{SessionKey}' session in database, session not found", session.Key);
+            return;
+        }
+        
+        session.UpdateEntity(existing);
+        
+        try
+        {
+            await dbContext.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "exception updating '{SessionKey}' session in database", session.Key);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteSession(string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        
+        Entities.IdentityServerServerSideSessions? existing = await dbContext.ServerSideSessions
+            .SingleOrDefaultAsync(x => x.Key == key);
+        
+        if (existing == null)
+        {
+            logger.LogError("failed deleting '{SessionKey}' session in database, session not found", key);
+            return;
+        }
+
+        dbContext.ServerSideSessions.Remove(existing);
+        
+        try
+        {
+            await dbContext.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "exception deleting '{SessionKey}' session in database", key);
+        }
+    }
+}

--- a/src/EntityFramework.Storage/src/Stores/Compatibility/IdentityServerServerSideSessionStore.cs
+++ b/src/EntityFramework.Storage/src/Stores/Compatibility/IdentityServerServerSideSessionStore.cs
@@ -4,27 +4,30 @@
 #nullable enable
 
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Open.IdentityServer.EntityFramework.Interfaces;
 using Open.IdentityServer.EntityFramework.Mappers;
+using Open.IdentityServer.Services;
 using Open.IdentityServer.Stores;
 using IdentityServerServerSideSessions = Open.IdentityServer.Models.IdentityServerServerSideSessions;
 
 namespace Open.IdentityServer.EntityFramework.Stores;
 
 /// <summary>
-/// Storage and retrieval of server side sessions using entity framework core
+/// Storage and retrieval of server-side sessions using entity framework core
 /// </summary>
 public class IdentityServerServerSideSessionStore(
     IPersistedGrantDbContext dbContext,
+    ITelemetryService telemetry,
     ILogger<IdentityServerServerSideSessionStore> logger): IIdentityServerServerSideSessionStore
 {
     /// <inheritdoc />
     public async Task<IdentityServerServerSideSessions?> GetSession(string key)
     {
+        using var trace = telemetry.Trace(TelemetryConstants.TraceCategories.Stores, this);
+        
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
 
         Entities.IdentityServerServerSideSessions? session = await dbContext.ServerSideSessions
@@ -36,6 +39,8 @@ public class IdentityServerServerSideSessionStore(
     /// <inheritdoc />
     public async Task CreateSession(IdentityServerServerSideSessions session)
     {
+        using var trace = telemetry.Trace(TelemetryConstants.TraceCategories.Stores, this);
+        
         ArgumentException.ThrowIfNullOrWhiteSpace(session.Key);
         
         Entities.IdentityServerServerSideSessions? existing = await dbContext.ServerSideSessions
@@ -64,6 +69,8 @@ public class IdentityServerServerSideSessionStore(
     /// <inheritdoc />
     public async Task UpdateSession(IdentityServerServerSideSessions session)
     {
+        using var trace = telemetry.Trace(TelemetryConstants.TraceCategories.Stores, this);
+        
         ArgumentException.ThrowIfNullOrWhiteSpace(session.Key);
         
         Entities.IdentityServerServerSideSessions? existing = await dbContext.ServerSideSessions
@@ -90,6 +97,8 @@ public class IdentityServerServerSideSessionStore(
     /// <inheritdoc />
     public async Task DeleteSession(string key)
     {
+        using var trace = telemetry.Trace(TelemetryConstants.TraceCategories.Stores, this);
+        
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
         
         Entities.IdentityServerServerSideSessions? existing = await dbContext.ServerSideSessions

--- a/src/EntityFramework.Storage/test/IntegrationTests/MockLogger.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/MockLogger.cs
@@ -8,7 +8,7 @@ public class MockLogger<T> : ILogger<T>
 {
     private readonly ILogger<T> _mock = Mock.Of<ILogger<T>>();
 
-    public static FakeLogger<T> Create() => new();
+    public static MockLogger<T> Create() => new();
 
     public IDisposable? BeginScope<TState>(TState state) where TState : notnull
         => _mock.BeginScope(state);

--- a/src/EntityFramework.Storage/test/IntegrationTests/MockLogger.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/MockLogger.cs
@@ -1,0 +1,47 @@
+using System;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Open.IdentityServer.EntityFramework.IntegrationTests;
+
+public class MockLogger<T> : ILogger<T>
+{
+    private readonly ILogger<T> _mock = Mock.Of<ILogger<T>>();
+
+    public static FakeLogger<T> Create() => new();
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+        => _mock.BeginScope(state);
+
+    public bool IsEnabled(LogLevel logLevel)
+        => _mock.IsEnabled(logLevel);
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        => _mock.Log(logLevel, eventId, state, exception, formatter);
+
+    public void VerifyLog(LogLevel level, string message, Times? times = null)
+    {
+        Mock.Get(_mock)
+            .Verify(
+            x => x.Log(
+                level,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains(message)),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            times ?? Times.Once());
+    }
+
+    public void VerifyLog(LogLevel level, Times? times = null)
+    {
+        Mock.Get(_mock)
+            .Verify(
+            x => x.Log(
+                level,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            times ?? Times.Once());
+    }
+}

--- a/src/EntityFramework.Storage/test/IntegrationTests/MockLogger.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/MockLogger.cs
@@ -1,3 +1,8 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+#nullable enable
+
 using System;
 using Microsoft.Extensions.Logging;
 using Moq;

--- a/src/EntityFramework.Storage/test/IntegrationTests/Stores/Compatibility/IdentityServerServerSideSessionStoreTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/Stores/Compatibility/IdentityServerServerSideSessionStoreTests.cs
@@ -1,0 +1,322 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Open.IdentityServer.EntityFramework.DbContexts;
+using Open.IdentityServer.EntityFramework.Entities;
+using Open.IdentityServer.EntityFramework.Options;
+using Open.IdentityServer.EntityFramework.Stores;
+using Xunit;
+using SessionModel = Open.IdentityServer.Models.IdentityServerServerSideSessions;
+
+namespace Open.IdentityServer.EntityFramework.IntegrationTests.Stores.Compatibility;
+
+public class IdentityServerServerSideSessionStoreTests: IntegrationTest<IdentityServerServerSideSessionStoreTests, PersistedGrantDbContext, OperationalStoreOptions>
+{
+    private readonly MockLogger<IdentityServerServerSideSessionStore> fakeLogger = new();
+    
+    public IdentityServerServerSideSessionStoreTests(DatabaseProviderFixture<PersistedGrantDbContext> fixture) : base(fixture)
+    {
+        foreach (var row in TestDatabaseProviders)
+        {
+            using var context = new PersistedGrantDbContext(row.Data, StoreOptions);
+            context.Database.EnsureCreated();
+        }
+    }
+
+    private IdentityServerServerSideSessionStore CreateSut(PersistedGrantDbContext dbContext) =>
+        new(dbContext, fakeLogger);
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task GetSession_WhenKeyNullOrEmpty_ShouldThrowArgumentException(string key)
+    {
+        await using var context = await CreateCleanContext(TestDatabaseProviders.FirstOrDefault());
+        var sut = CreateSut(context);
+        
+        Func<Task> act = async () => await sut.GetSession(key);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+    
+    [Theory, MemberData(nameof(TestDatabaseProviders))]
+    public async Task GetSession_WhenDoesntExist_ShouldReturnNull(DbContextOptions<PersistedGrantDbContext> options)
+    {
+        await using var context = await CreateCleanContext(options);
+        var sut = CreateSut(context);
+
+        var result = await sut.GetSession("missing-key");
+
+        result.Should().BeNull();
+    }
+
+    [Theory, MemberData(nameof(TestDatabaseProviders))]
+    public async Task GetSession_WhenExist_ShouldReturnValue(DbContextOptions<PersistedGrantDbContext> options)
+    {
+        await using var context = await CreateCleanContext(options);
+
+        var key = "session-key-1";
+        var seeded = new IdentityServerServerSideSessions
+        {
+            Key = key,
+            Scheme = "cookie",
+            SubjectId = "sub-1",
+            SessionId = "sid-1",
+            DisplayName = "display-1",
+            Created = DateTime.UtcNow.AddMinutes(-10),
+            Renewed = DateTime.UtcNow.AddMinutes(-5),
+            Expires = DateTime.UtcNow.AddMinutes(30),
+            Data = "{\"foo\":\"bar\"}"
+        };
+
+        context.ServerSideSessions.Add(seeded);
+        await context.SaveChangesAsync();
+
+        var sut = CreateSut(context);
+
+        var result = await sut.GetSession(key);
+
+        result.Should().NotBeNull();
+        result!.Key.Should().Be(seeded.Key);
+        result.Scheme.Should().Be(seeded.Scheme);
+        result.SubjectId.Should().Be(seeded.SubjectId);
+        result.SessionId.Should().Be(seeded.SessionId);
+        result.DisplayName.Should().Be(seeded.DisplayName);
+        result.Created.Should().Be(seeded.Created);
+        result.Renewed.Should().Be(seeded.Renewed);
+        result.Expires.Should().Be(seeded.Expires);
+        result.Data.Should().Be(seeded.Data);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task CreateSession_WhenKeyNullOrEmpty_ShouldThrowArgumentException(string key)
+    {
+        await using var context = await CreateCleanContext(TestDatabaseProviders.FirstOrDefault());
+        var sut = CreateSut(context);
+        
+        var newSession = BuildSessionModel(key, "sub-new", "sid-new", "new");
+        
+        Func<Task> act = async () => await sut.CreateSession(newSession);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Theory, MemberData(nameof(TestDatabaseProviders))]
+    public async Task CreateSession_WhenSessionAlreadyExistsWithKey_ShouldLogError(DbContextOptions<PersistedGrantDbContext> options)
+    {
+        await using var context = await CreateCleanContext(options);
+
+        var key = "duplicate-key";
+        context.ServerSideSessions.Add(new IdentityServerServerSideSessions
+        {
+            Key = key,
+            Scheme = "cookie",
+            SubjectId = "sub-existing",
+            SessionId = "sid-existing",
+            DisplayName = "existing",
+            Created = DateTime.UtcNow.AddMinutes(-20),
+            Renewed = DateTime.UtcNow.AddMinutes(-10),
+            Expires = DateTime.UtcNow.AddMinutes(20),
+            Data = "{\"state\":\"existing\"}"
+        });
+        await context.SaveChangesAsync();
+
+        var sut = CreateSut(context);
+        var newSession = BuildSessionModel(key, "sub-new", "sid-new", "new");
+
+        await sut.CreateSession(newSession);
+        
+        fakeLogger.VerifyLog(LogLevel.Error, Times.AtLeastOnce());
+    }
+
+    [Theory, MemberData(nameof(TestDatabaseProviders))]
+    public async Task CreateSession_WhenSessionDoesntExistsWithKey_ShouldStoreSessionInDatabase(DbContextOptions<PersistedGrantDbContext> options)
+    {
+        await using var context = await CreateCleanContext(options);
+
+        var key = "new-key";
+        var session = BuildSessionModel(key, "sub-123", "sid-123", "display-123");
+
+        var sut = CreateSut(context);
+
+        await sut.CreateSession(session);
+
+        var stored = await context.ServerSideSessions
+            .AsNoTracking()
+            .SingleOrDefaultAsync(x => x.Key == key, cancellationToken: TestContext.Current.CancellationToken);
+        
+        stored.Should().NotBeNull();
+        stored!.Key.Should().Be(session.Key);
+        stored.Scheme.Should().Be(session.Scheme);
+        stored.SubjectId.Should().Be(session.SubjectId);
+        stored.SessionId.Should().Be(session.SessionId);
+        stored.DisplayName.Should().Be(session.DisplayName);
+        stored.Created.Should().Be(session.Created);
+        stored.Renewed.Should().Be(session.Renewed);
+        stored.Expires.Should().Be(session.Expires);
+        stored.Data.Should().Be(session.Data);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task UpdateSession_WhenKeyNullOrEmpty_ShouldThrowArgumentException(string key)
+    {
+        await using var context = await CreateCleanContext(TestDatabaseProviders.FirstOrDefault());
+        var sut = CreateSut(context);
+        
+        var session = BuildSessionModel(key, "sub-new", "sid-new", "new");
+        
+        Func<Task> act = async () => await sut.UpdateSession(session);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Theory, MemberData(nameof(TestDatabaseProviders))]
+    public async Task UpdateSession_WhenSessionDoesntExistsWithKey_ShouldLogError(DbContextOptions<PersistedGrantDbContext> options)
+    {
+        await using var context = await CreateCleanContext(options);
+        var sut = CreateSut(context);
+
+        var session = BuildSessionModel("missing-update-key", "sub", "sid", "display");
+
+        await sut.UpdateSession(session);
+        
+        fakeLogger.VerifyLog(LogLevel.Error, Times.AtLeastOnce());
+    }
+
+    [Theory, MemberData(nameof(TestDatabaseProviders))]
+    public async Task UpdateSession_WhenSessionExistsWithKey_ShouldUpdateStoredSession(DbContextOptions<PersistedGrantDbContext> options)
+    {
+        await using var context = await CreateCleanContext(options);
+
+        var key = "update-key";
+        context.ServerSideSessions.Add(new IdentityServerServerSideSessions
+        {
+            Key = key,
+            Scheme = "old-scheme",
+            SubjectId = "old-sub",
+            SessionId = "old-sid",
+            DisplayName = "old-display",
+            Created = DateTime.UtcNow.AddHours(-2),
+            Renewed = DateTime.UtcNow.AddHours(-1),
+            Expires = DateTime.UtcNow.AddMinutes(5),
+            Data = "{\"version\":1}"
+        });
+        await context.SaveChangesAsync();
+
+        var updated = BuildSessionModel(key, "new-sub", "new-sid", "new-display");
+        updated.Scheme = "new-scheme";
+        updated.Data = "{\"version\":2}";
+        updated.Created = DateTime.UtcNow.AddHours(-3);
+        updated.Renewed = DateTime.UtcNow.AddMinutes(-1);
+        updated.Expires = DateTime.UtcNow.AddHours(2);
+
+        var sut = CreateSut(context);
+
+        await sut.UpdateSession(updated);
+
+        var stored = await context.ServerSideSessions
+            .AsNoTracking()
+            .SingleAsync(x => x.Key == key, cancellationToken: TestContext.Current.CancellationToken);
+        
+        stored.Key.Should().Be(updated.Key);
+        stored.Scheme.Should().Be(updated.Scheme);
+        stored.SubjectId.Should().Be(updated.SubjectId);
+        stored.SessionId.Should().Be(updated.SessionId);
+        stored.DisplayName.Should().Be(updated.DisplayName);
+        stored.Created.Should().Be(updated.Created);
+        stored.Renewed.Should().Be(updated.Renewed);
+        stored.Expires.Should().Be(updated.Expires);
+        stored.Data.Should().Be(updated.Data);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task DeleteSession_WhenKeyNullOrEmpty_ShouldThrowArgumentException(string key)
+    {
+        await using var context = await CreateCleanContext(TestDatabaseProviders.FirstOrDefault());
+        var sut = CreateSut(context);
+        
+        Func<Task> act = async () => await sut.DeleteSession(key);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+    
+    [Theory, MemberData(nameof(TestDatabaseProviders))]
+    public async Task DeleteSession_WhenSessionDoesntExistsWithKey_ShouldLogError(DbContextOptions<PersistedGrantDbContext> options)
+    {
+        await using var context = await CreateCleanContext(options);
+        var sut = CreateSut(context);
+
+        await sut.DeleteSession("missing-delete-key");
+        
+        fakeLogger.VerifyLog(LogLevel.Error, Times.AtLeastOnce());
+    }
+
+    [Theory, MemberData(nameof(TestDatabaseProviders))]
+    public async Task DeleteSession_WhenSessionExistsWithKey_ShouldDeleteStoredSession(DbContextOptions<PersistedGrantDbContext> options)
+    {
+        await using var context = await CreateCleanContext(options);
+
+        var key = "delete-key";
+        context.ServerSideSessions.Add(new IdentityServerServerSideSessions
+        {
+            Key = key,
+            Scheme = "cookie",
+            SubjectId = "sub-delete",
+            SessionId = "sid-delete",
+            DisplayName = "delete me",
+            Created = DateTime.UtcNow.AddMinutes(-30),
+            Renewed = DateTime.UtcNow.AddMinutes(-15),
+            Expires = DateTime.UtcNow.AddMinutes(30),
+            Data = "{\"delete\":true}"
+        });
+        await context.SaveChangesAsync();
+
+        var sut = CreateSut(context);
+
+        await sut.DeleteSession(key);
+
+        var stored = await context.ServerSideSessions
+            .AsNoTracking()
+            .SingleOrDefaultAsync(x => x.Key == key, cancellationToken: TestContext.Current.CancellationToken);
+        
+        stored.Should().BeNull();
+    }
+
+    private async Task<PersistedGrantDbContext> CreateCleanContext(DbContextOptions<PersistedGrantDbContext> options)
+    {
+        var context = new PersistedGrantDbContext(options, StoreOptions);
+        await context.Database.EnsureDeletedAsync();
+        await context.Database.EnsureCreatedAsync();
+        return context;
+    }
+
+    private static SessionModel BuildSessionModel(string key, string subjectId, string sessionId, string displayName)
+    {
+        return new SessionModel
+        {
+            Key = key,
+            Scheme = "cookie",
+            SubjectId = subjectId,
+            SessionId = sessionId,
+            DisplayName = displayName,
+            Created = DateTime.UtcNow.AddMinutes(-10),
+            Renewed = DateTime.UtcNow.AddMinutes(-5),
+            Expires = DateTime.UtcNow.AddHours(1),
+            Data = "{\"payload\":\"value\"}"
+        };
+    }
+}

--- a/src/EntityFramework.Storage/test/IntegrationTests/Stores/Compatibility/IdentityServerServerSideSessionStoreTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/Stores/Compatibility/IdentityServerServerSideSessionStoreTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using AwesomeAssertions;
@@ -9,6 +10,7 @@ using Open.IdentityServer.EntityFramework.DbContexts;
 using Open.IdentityServer.EntityFramework.Entities;
 using Open.IdentityServer.EntityFramework.Options;
 using Open.IdentityServer.EntityFramework.Stores;
+using Open.IdentityServer.Services;
 using Xunit;
 using SessionModel = Open.IdentityServer.Models.IdentityServerServerSideSessions;
 
@@ -16,19 +18,20 @@ namespace Open.IdentityServer.EntityFramework.IntegrationTests.Stores.Compatibil
 
 public class IdentityServerServerSideSessionStoreTests: IntegrationTest<IdentityServerServerSideSessionStoreTests, PersistedGrantDbContext, OperationalStoreOptions>
 {
+    private readonly ITelemetryService telemetry = Mock.Of<ITelemetryService>();
     private readonly MockLogger<IdentityServerServerSideSessionStore> fakeLogger = new();
     
     public IdentityServerServerSideSessionStoreTests(DatabaseProviderFixture<PersistedGrantDbContext> fixture) : base(fixture)
     {
-        foreach (var row in TestDatabaseProviders)
+        foreach (TheoryDataRow<DbContextOptions<PersistedGrantDbContext>> row in TestDatabaseProviders)
         {
-            using var context = new PersistedGrantDbContext(row.Data, StoreOptions);
+            using PersistedGrantDbContext context = new PersistedGrantDbContext(row.Data, StoreOptions);
             context.Database.EnsureCreated();
         }
     }
 
     private IdentityServerServerSideSessionStore CreateSut(PersistedGrantDbContext dbContext) =>
-        new(dbContext, fakeLogger);
+        new(dbContext, telemetry, fakeLogger);
 
     [Theory]
     [InlineData(null)]
@@ -37,7 +40,7 @@ public class IdentityServerServerSideSessionStoreTests: IntegrationTest<Identity
     public async Task GetSession_WhenKeyNullOrEmpty_ShouldThrowArgumentException(string key)
     {
         await using var context = await CreateCleanContext(TestDatabaseProviders.FirstOrDefault());
-        var sut = CreateSut(context);
+        IdentityServerServerSideSessionStore sut = CreateSut(context);
         
         Func<Task> act = async () => await sut.GetSession(key);
 
@@ -48,9 +51,9 @@ public class IdentityServerServerSideSessionStoreTests: IntegrationTest<Identity
     public async Task GetSession_WhenDoesntExist_ShouldReturnNull(DbContextOptions<PersistedGrantDbContext> options)
     {
         await using var context = await CreateCleanContext(options);
-        var sut = CreateSut(context);
+        IdentityServerServerSideSessionStore sut = CreateSut(context);
 
-        var result = await sut.GetSession("missing-key");
+        SessionModel result = await sut.GetSession("missing-key");
 
         result.Should().BeNull();
     }
@@ -60,8 +63,8 @@ public class IdentityServerServerSideSessionStoreTests: IntegrationTest<Identity
     {
         await using var context = await CreateCleanContext(options);
 
-        var key = "session-key-1";
-        var seeded = new IdentityServerServerSideSessions
+        string key = "session-key-1";
+        IdentityServerServerSideSessions seeded = new IdentityServerServerSideSessions
         {
             Key = key,
             Scheme = "cookie",
@@ -77,9 +80,9 @@ public class IdentityServerServerSideSessionStoreTests: IntegrationTest<Identity
         context.ServerSideSessions.Add(seeded);
         await context.SaveChangesAsync();
 
-        var sut = CreateSut(context);
+        IdentityServerServerSideSessionStore sut = CreateSut(context);
 
-        var result = await sut.GetSession(key);
+        SessionModel result = await sut.GetSession(key);
 
         result.Should().NotBeNull();
         result!.Key.Should().Be(seeded.Key);
@@ -100,7 +103,7 @@ public class IdentityServerServerSideSessionStoreTests: IntegrationTest<Identity
     public async Task CreateSession_WhenKeyNullOrEmpty_ShouldThrowArgumentException(string key)
     {
         await using var context = await CreateCleanContext(TestDatabaseProviders.FirstOrDefault());
-        var sut = CreateSut(context);
+        IdentityServerServerSideSessionStore sut = CreateSut(context);
         
         var newSession = BuildSessionModel(key, "sub-new", "sid-new", "new");
         
@@ -114,7 +117,7 @@ public class IdentityServerServerSideSessionStoreTests: IntegrationTest<Identity
     {
         await using var context = await CreateCleanContext(options);
 
-        var key = "duplicate-key";
+        string key = "duplicate-key";
         context.ServerSideSessions.Add(new IdentityServerServerSideSessions
         {
             Key = key,
@@ -129,7 +132,7 @@ public class IdentityServerServerSideSessionStoreTests: IntegrationTest<Identity
         });
         await context.SaveChangesAsync();
 
-        var sut = CreateSut(context);
+        IdentityServerServerSideSessionStore sut = CreateSut(context);
         var newSession = BuildSessionModel(key, "sub-new", "sid-new", "new");
 
         await sut.CreateSession(newSession);
@@ -142,10 +145,10 @@ public class IdentityServerServerSideSessionStoreTests: IntegrationTest<Identity
     {
         await using var context = await CreateCleanContext(options);
 
-        var key = "new-key";
+        string key = "new-key";
         var session = BuildSessionModel(key, "sub-123", "sid-123", "display-123");
 
-        var sut = CreateSut(context);
+        IdentityServerServerSideSessionStore sut = CreateSut(context);
 
         await sut.CreateSession(session);
 
@@ -172,7 +175,7 @@ public class IdentityServerServerSideSessionStoreTests: IntegrationTest<Identity
     public async Task UpdateSession_WhenKeyNullOrEmpty_ShouldThrowArgumentException(string key)
     {
         await using var context = await CreateCleanContext(TestDatabaseProviders.FirstOrDefault());
-        var sut = CreateSut(context);
+        IdentityServerServerSideSessionStore sut = CreateSut(context);
         
         var session = BuildSessionModel(key, "sub-new", "sid-new", "new");
         
@@ -185,7 +188,7 @@ public class IdentityServerServerSideSessionStoreTests: IntegrationTest<Identity
     public async Task UpdateSession_WhenSessionDoesntExistsWithKey_ShouldLogError(DbContextOptions<PersistedGrantDbContext> options)
     {
         await using var context = await CreateCleanContext(options);
-        var sut = CreateSut(context);
+        IdentityServerServerSideSessionStore sut = CreateSut(context);
 
         var session = BuildSessionModel("missing-update-key", "sub", "sid", "display");
 
@@ -199,7 +202,7 @@ public class IdentityServerServerSideSessionStoreTests: IntegrationTest<Identity
     {
         await using var context = await CreateCleanContext(options);
 
-        var key = "update-key";
+        string key = "update-key";
         context.ServerSideSessions.Add(new IdentityServerServerSideSessions
         {
             Key = key,
@@ -221,7 +224,7 @@ public class IdentityServerServerSideSessionStoreTests: IntegrationTest<Identity
         updated.Renewed = DateTime.UtcNow.AddMinutes(-1);
         updated.Expires = DateTime.UtcNow.AddHours(2);
 
-        var sut = CreateSut(context);
+        IdentityServerServerSideSessionStore sut = CreateSut(context);
 
         await sut.UpdateSession(updated);
 
@@ -247,7 +250,7 @@ public class IdentityServerServerSideSessionStoreTests: IntegrationTest<Identity
     public async Task DeleteSession_WhenKeyNullOrEmpty_ShouldThrowArgumentException(string key)
     {
         await using var context = await CreateCleanContext(TestDatabaseProviders.FirstOrDefault());
-        var sut = CreateSut(context);
+        IdentityServerServerSideSessionStore sut = CreateSut(context);
         
         Func<Task> act = async () => await sut.DeleteSession(key);
 
@@ -258,7 +261,7 @@ public class IdentityServerServerSideSessionStoreTests: IntegrationTest<Identity
     public async Task DeleteSession_WhenSessionDoesntExistsWithKey_ShouldLogError(DbContextOptions<PersistedGrantDbContext> options)
     {
         await using var context = await CreateCleanContext(options);
-        var sut = CreateSut(context);
+        IdentityServerServerSideSessionStore sut = CreateSut(context);
 
         await sut.DeleteSession("missing-delete-key");
         
@@ -270,7 +273,7 @@ public class IdentityServerServerSideSessionStoreTests: IntegrationTest<Identity
     {
         await using var context = await CreateCleanContext(options);
 
-        var key = "delete-key";
+        string key = "delete-key";
         context.ServerSideSessions.Add(new IdentityServerServerSideSessions
         {
             Key = key,
@@ -285,7 +288,7 @@ public class IdentityServerServerSideSessionStoreTests: IntegrationTest<Identity
         });
         await context.SaveChangesAsync();
 
-        var sut = CreateSut(context);
+        IdentityServerServerSideSessionStore sut = CreateSut(context);
 
         await sut.DeleteSession(key);
 
@@ -295,10 +298,51 @@ public class IdentityServerServerSideSessionStoreTests: IntegrationTest<Identity
         
         stored.Should().BeNull();
     }
+    
+    [Theory, MemberData(nameof(TestDatabaseProviders))]
+    public async Task PublicMethods_WhenCalled_ShouldTelemetryTrace(DbContextOptions<PersistedGrantDbContext> options)
+    {
+        List<(Func<IdentityServerServerSideSessionStore, Task> actMethod, string traceMethodName)> methods
+            = new()
+            {
+                (store => store.CreateSession(new SessionModel { Key = "FAKE_SESSION_KEY" }), "CreateSession"),
+                (store => store.GetSession("FAKE_SESSION_KEY"), "GetSession"),
+                (store => store.UpdateSession(new SessionModel { Key = "FAKE_SESSION_KEY" }), "UpdateSession"),
+                (store => store.DeleteSession("FAKE_SESSION_KEY"), "DeleteSession"),
+            };
+
+        foreach (var method in methods)
+        {
+            var trace = Mock.Of<ITrace>();
+            Mock.Get(telemetry).Setup(t => t.Trace(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<string>()))
+                .Returns(trace);
+            Mock.Get(trace).Setup(t => t.AddTag(It.IsAny<string>(), It.IsAny<string>())).Returns(trace);
+            Mock.Get(trace).Setup(t => t.AddTag(It.IsAny<string>(), It.IsAny<object>())).Returns(trace);
+
+            await using PersistedGrantDbContext context = new PersistedGrantDbContext(options, StoreOptions);
+            
+            var store = CreateSut(context);
+                
+            await method.actMethod(store);
+
+            Mock.Get(telemetry)
+                .Verify(t => t.Trace(
+                    TelemetryConstants.TraceCategories.Stores, store, method.traceMethodName), Times.Once);
+            Mock.Get(trace).Verify(t => t.Dispose(), Times.Once);
+        }
+        
+        // Assert all methods covered
+        typeof(IdentityServerServerSideSessionStore).GetMethods()
+            .Where(m => m.IsPublic && !m.IsStatic && !m.IsSpecialName)
+            .Where(m => m.DeclaringType == typeof(IdentityServerServerSideSessionStore))
+            .Select(m => m.Name)
+            .Distinct()
+            .Should().BeEquivalentTo(methods.Select(m => m.traceMethodName));
+    }
 
     private async Task<PersistedGrantDbContext> CreateCleanContext(DbContextOptions<PersistedGrantDbContext> options)
     {
-        var context = new PersistedGrantDbContext(options, StoreOptions);
+        PersistedGrantDbContext context = new PersistedGrantDbContext(options, StoreOptions);
         await context.Database.EnsureDeletedAsync();
         await context.Database.EnsureCreatedAsync();
         return context;

--- a/src/EntityFramework.Storage/test/UnitTests/Mappers/IdentityServerServerSideSessionsExtensionsTests.cs
+++ b/src/EntityFramework.Storage/test/UnitTests/Mappers/IdentityServerServerSideSessionsExtensionsTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System;
+using AwesomeAssertions;
+using Open.IdentityServer.EntityFramework.Entities;
+using Open.IdentityServer.EntityFramework.Mappers;
+using Xunit;
+
+namespace Open.IdentityServer.EntityFramework.UnitTests.Mappers;
+
+public class IdentityServerServerSideSessionsExtensionsTests
+{
+    [Fact]
+    public void EntityIdentityServerServerSideSessions_ToModel_ProducesModelWithCorrectFields()
+    {
+        IdentityServerServerSideSessions entity = new IdentityServerServerSideSessions
+        {
+            Id = 1,
+            Key = Guid.NewGuid().ToString(),
+            Scheme = "FakeScheme",
+            SubjectId = "fake-subject",
+            SessionId = "fake-session",
+            DisplayName = "Fake Session for User",
+            Created = new DateTime(2020, 01, 01, 12, 20, 0, DateTimeKind.Utc),
+            Renewed = new DateTime(2020, 02, 01, 12, 20, 0, DateTimeKind.Utc),
+            Expires = new DateTime(2020, 03, 01, 12, 20, 0, DateTimeKind.Utc),
+            Data = "FAKEPROTECTEDDATA"
+        };
+
+        Models.IdentityServerServerSideSessions actual = entity.ToModel();
+
+        entity.Should().BeEquivalentTo(actual);
+    }
+    
+    [Fact]
+    public void ModelIdentityServerServerSideSessions_ToEntity_ProducesEntityWithCorrectFields()
+    {
+        Models.IdentityServerServerSideSessions model = new Models.IdentityServerServerSideSessions
+        {
+            Key = Guid.NewGuid().ToString(),
+            Scheme = "FakeScheme",
+            SubjectId = "fake-subject",
+            SessionId = "fake-session",
+            DisplayName = "Fake Session for User",
+            Created = new DateTime(2020, 01, 01, 12, 20, 0, DateTimeKind.Utc),
+            Renewed = new DateTime(2020, 02, 01, 12, 20, 0, DateTimeKind.Utc),
+            Expires = new DateTime(2020, 03, 01, 12, 20, 0, DateTimeKind.Utc),
+            Data = "FAKEPROTECTEDDATA"
+        };
+
+        IdentityServerServerSideSessions actual = model.ToEntity();
+        
+        model.Should().BeEquivalentTo(actual, cnf => cnf.Excluding(x => x.Id));
+    }
+}

--- a/src/EntityFramework/src/IdentityServerEntityFrameworkBuilderExtensions.cs
+++ b/src/EntityFramework/src/IdentityServerEntityFrameworkBuilderExtensions.cs
@@ -102,6 +102,7 @@ public static class IdentityServerEntityFrameworkBuilderExtensions
 
         builder.Services.AddTransient<IPersistedGrantStore, PersistedGrantStore>();
         builder.Services.AddTransient<IDeviceFlowStore, DeviceFlowStore>();
+        builder.Services.AddTransient<IIdentityServerServerSideSessionStore, IdentityServerServerSideSessionStore>();
         builder.Services.AddSingleton<IHostedService, TokenCleanupHost>();
         
         builder.Services.AddScoped<IIdentityServerKeyStore, IdentityServerKeyStore>();

--- a/src/Open.IdentityServer/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
+++ b/src/Open.IdentityServer/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
@@ -473,6 +473,9 @@ public static class IdentityServerBuilderExtensionsAdditional
     {
         builder.Services.AddSingleton<IPostConfigureOptions<CookieAuthenticationOptions>, PostConfigureSessionStoreCookieAuthOptions>();
         builder.Services.AddScoped<ITicketStore, ServerSessionTicketStore>();
+        
+        // provide default in-memory implementation, not suitable for most production scenarios (following pattern implemented with existing stores)
+        builder.Services.TryAddSingleton<IIdentityServerServerSideSessionStore, InMemorySessionStore>();
 
         return builder;
     }

--- a/src/Open.IdentityServer/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
+++ b/src/Open.IdentityServer/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
@@ -10,9 +10,12 @@ using Open.IdentityServer.Validation;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
 using System.Net.Http;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Open.IdentityServer;
 using Open.IdentityServer.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Open.IdentityServer.Models;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -457,6 +460,19 @@ public static class IdentityServerBuilderExtensionsAdditional
         // This is added as scoped due to the note regarding the AuthenticateAsync
         // method in the Open.IdentityServer.Services.DefaultUserSession implementation.
         builder.Services.AddScoped<IUserSession, T>();
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds server-side session storage to Open.IdentityServer
+    /// </summary>
+    /// <param name="builder">The builder</param>
+    /// <returns>The same <paramref name="builder"/> instance so that additional calls can be chained</returns>
+    public static IIdentityServerBuilder AddServerSideSessions(this IIdentityServerBuilder builder)
+    {
+        builder.Services.AddSingleton<IPostConfigureOptions<CookieAuthenticationOptions>, PostConfigureSessionStoreCookieAuthOptions>();
+        builder.Services.AddScoped<ITicketStore, ServerSessionTicketStore>();
 
         return builder;
     }

--- a/src/Open.IdentityServer/src/Configuration/PostConfigureSessionStoreCookieAuthOptions.cs
+++ b/src/Open.IdentityServer/src/Configuration/PostConfigureSessionStoreCookieAuthOptions.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.Extensions.Options;
+
+namespace Open.IdentityServer.Configuration;
+
+/// <summary>
+/// IPostConfigureOptions implementation for <see cref="CookieAuthenticationOptions"/>. Registers the <see cref="ITicketStore"/>
+/// implementation to use for storing auth tickets.
+/// </summary>
+/// <param name="ticketStore">instance of ITicketStore to use</param>
+/// <param name="idsOptions">Open.IdentityServer options</param>
+/// <param name="authOptions">Authentication options</param>
+public class PostConfigureSessionStoreCookieAuthOptions(
+    ITicketStore ticketStore,
+    IdentityServerOptions idsOptions,
+    IOptions<Microsoft.AspNetCore.Authentication.AuthenticationOptions> authOptions): IPostConfigureOptions<CookieAuthenticationOptions>
+{
+    /// <summary>
+    /// Implementation of post configure setting <see cref="CookieAuthenticationOptions"/> SessionStore parameter if
+    /// name provided matches scheme
+    /// </summary>
+    /// <param name="name">name of the scheme</param>
+    /// <param name="options">cookie authentication options</param>
+    public void PostConfigure(string name, CookieAuthenticationOptions options)
+    {
+        var scheme = idsOptions.Authentication.CookieAuthenticationScheme ??
+            authOptions.Value.DefaultAuthenticateScheme ??
+            authOptions.Value.DefaultScheme;
+
+        if (scheme == name)
+        {
+            options.SessionStore = ticketStore;
+        }
+    }
+}

--- a/src/Open.IdentityServer/src/DataProtection/DataProtectedGrantData.cs
+++ b/src/Open.IdentityServer/src/DataProtection/DataProtectedGrantData.cs
@@ -24,9 +24,7 @@ public class DataProtectedGrantData
     public bool DataProtected { get; set; }
     
     /// <summary>
-    /// <see langword="true"/> when <see cref="Payload"/> has been protected via
-    /// <c>IDataProtector.Protect</c> and must be unprotected before deserialization;
-    /// <see langword="false"/> when the payload is the raw serialized grant.
+    /// Payload of the grant data, either raw JSON or protected string
     /// </summary>
     public string Payload { get; set; }
 }

--- a/src/Open.IdentityServer/src/DataProtection/DataProtectedSessionData.cs
+++ b/src/Open.IdentityServer/src/DataProtection/DataProtectedSessionData.cs
@@ -1,0 +1,20 @@
+namespace Open.IdentityServer.DataProtection;
+
+/// <summary>
+/// Envelope used by <see cref="Open.IdentityServer.Stores.ServerSessionTicketStore"/>
+/// to wrap a serialized server session payload together with the metadata needed
+/// to determine the version of the envelope.
+/// </summary>
+public class DataProtectedSessionData
+{
+    /// <summary>
+    /// Schema version of this envelope.
+    /// Incremented when the shape of the payload changes.
+    /// </summary>
+    public int Version { get; set; } = 1;
+    
+    /// <summary>
+    /// Payload of the grant data, either raw JSON or protected string
+    /// </summary>
+    public string Payload { get; set; }
+}

--- a/src/Open.IdentityServer/src/DataProtectionConstants.cs
+++ b/src/Open.IdentityServer/src/DataProtectionConstants.cs
@@ -10,4 +10,7 @@ public static class DataProtectionConstants
 {
     /// <summary>Purpose used when creating key material data protector.</summary>
     public const string KeyProtectorPurpose = "DataProtectionKeyProtector";
+
+    /// <summary>Purpose used when creating server side ticket store data protector.</summary>
+    public const string ServerSideTicketStorePurpose = "Duende.SessionManagement.ServerSideTicketStore";
 }

--- a/src/Open.IdentityServer/src/Extensions/AuthenticationTicketSerialiser.cs
+++ b/src/Open.IdentityServer/src/Extensions/AuthenticationTicketSerialiser.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2026, Rock Solid Knowledge Ltd
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+using System.Linq;
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Open.IdentityServer.Stores.Serialization;
 
@@ -18,6 +20,17 @@ internal static class AuthenticationTicketExtensions
                 User = authenticationTicket.Principal.ToSerializableObj(),
                 Items = authenticationTicket.Properties.Items,
             };
+        }
+    }
+
+    extension(SerializedAuthenticationTicket serializationAuthTicket)
+    {
+        public AuthenticationTicket ToAuthTicket()
+        {
+            return new AuthenticationTicket(
+                serializationAuthTicket.User.ToClaimsPrincipal(), 
+                new AuthenticationProperties(serializationAuthTicket.Items), 
+                serializationAuthTicket.Scheme);
         }
     }
 }

--- a/src/Open.IdentityServer/src/Extensions/AuthenticationTicketSerialiser.cs
+++ b/src/Open.IdentityServer/src/Extensions/AuthenticationTicketSerialiser.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using Microsoft.AspNetCore.Authentication;
+using Open.IdentityServer.Stores.Serialization;
+
+namespace Open.IdentityServer.Extensions;
+
+internal static class AuthenticationTicketExtensions
+{
+    extension(AuthenticationTicket authenticationTicket)
+    {
+        public SerializedAuthenticationTicket ToSerializableObj()
+        {
+            return new SerializedAuthenticationTicket
+            {
+                Scheme = authenticationTicket.AuthenticationScheme,
+                User = authenticationTicket.Principal.ToSerializableObj(),
+                Items = authenticationTicket.Properties.Items,
+            };
+        }
+    }
+}

--- a/src/Open.IdentityServer/src/Extensions/ClaimsExtensions.cs
+++ b/src/Open.IdentityServer/src/Extensions/ClaimsExtensions.cs
@@ -95,4 +95,9 @@ internal static class ClaimsExtensions
             Type = x.Type, Value = x.Value, ValueType = x.ValueType, Issuer = x.Issuer,
         }).ToArray();
     }
+    
+    public static Claim[] ToClaims(this ClaimLite[] claims)
+    {
+        return claims.Select(x => new Claim(x.Type, x.Value, x.ValueType, x.Issuer)).ToArray();
+    }
 }

--- a/src/Open.IdentityServer/src/Extensions/ClaimsExtensions.cs
+++ b/src/Open.IdentityServer/src/Extensions/ClaimsExtensions.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Modified by Rock Solid Knowledge Ltd. Copyright in modifications 2026, Rock Solid Knowledge Ltd.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
-
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Text.Json;
+using Open.IdentityServer.Stores.Serialization;
 
 namespace Open.IdentityServer.Extensions;
 
@@ -79,11 +80,19 @@ internal static class ClaimsExtensions
         {
             try
             {
-                return System.Text.Json.JsonSerializer.Deserialize<JsonElement>(claim.Value);
+                return JsonSerializer.Deserialize<JsonElement>(claim.Value);
             }
             catch { }
         }
 
         return claim.Value;
+    }
+    
+    public static ClaimLite[] ToSerializableObj(this IEnumerable<Claim> claims)
+    {
+        return claims.Select(x => new ClaimLite
+        {
+            Type = x.Type, Value = x.Value, ValueType = x.ValueType, Issuer = x.Issuer,
+        }).ToArray();
     }
 }

--- a/src/Open.IdentityServer/src/Extensions/ClaimsPrincipleExtension.cs
+++ b/src/Open.IdentityServer/src/Extensions/ClaimsPrincipleExtension.cs
@@ -19,4 +19,12 @@ internal static class ClaimsPrincipleExtension
             };
         }
     }
+    
+    extension(ClaimsPrincipalLite claimsPrincipalLite)
+    {
+        public ClaimsPrincipal ToClaimsPrincipal()
+        {
+            return new ClaimsPrincipal(new ClaimsIdentity(claimsPrincipalLite.Claims.ToClaims(), claimsPrincipalLite.AuthenticationType));
+        }
+    }
 }

--- a/src/Open.IdentityServer/src/Extensions/ClaimsPrincipleExtension.cs
+++ b/src/Open.IdentityServer/src/Extensions/ClaimsPrincipleExtension.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Security.Claims;
+using Open.IdentityServer.Stores.Serialization;
+
+namespace Open.IdentityServer.Extensions;
+
+internal static class ClaimsPrincipleExtension
+{
+    extension(ClaimsPrincipal claimsPrincipal)
+    {
+        public ClaimsPrincipalLite ToSerializableObj()
+        {
+            return new ClaimsPrincipalLite
+            {
+                AuthenticationType = claimsPrincipal.Identity!.AuthenticationType!,
+                Claims = claimsPrincipal.Claims.ToSerializableObj(),
+            };
+        }
+    }
+}

--- a/src/Open.IdentityServer/src/Extensions/ClaimsPrincipleExtension.cs
+++ b/src/Open.IdentityServer/src/Extensions/ClaimsPrincipleExtension.cs
@@ -19,12 +19,18 @@ internal static class ClaimsPrincipleExtension
             };
         }
     }
-    
+
     extension(ClaimsPrincipalLite claimsPrincipalLite)
     {
         public ClaimsPrincipal ToClaimsPrincipal()
         {
-            return new ClaimsPrincipal(new ClaimsIdentity(claimsPrincipalLite.Claims.ToClaims(), claimsPrincipalLite.AuthenticationType));
+            ClaimsIdentity identity = new ClaimsIdentity(
+                claimsPrincipalLite.Claims.ToClaims(),
+                claimsPrincipalLite.AuthenticationType, 
+                JwtClaimTypes.Name,
+                JwtClaimTypes.Role);
+            
+            return new ClaimsPrincipal(identity);
         }
     }
 }

--- a/src/Open.IdentityServer/src/Stores/Default/ServerSessionTicketStore.cs
+++ b/src/Open.IdentityServer/src/Stores/Default/ServerSessionTicketStore.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
 #nullable enable
 
 using System;

--- a/src/Open.IdentityServer/src/Stores/Default/ServerSessionTicketStore.cs
+++ b/src/Open.IdentityServer/src/Stores/Default/ServerSessionTicketStore.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging;
+using Open.IdentityServer.DataProtection;
 using Open.IdentityServer.Extensions;
 using Open.IdentityServer.Models;
 using Open.IdentityServer.Services;
@@ -59,28 +60,6 @@ public class ServerSessionTicketStore(
         return session.Key;
     }
 
-    private async Task<IdentityServerServerSideSessions> StoreNewSession(string key, AuthenticationTicket ticket)
-    {
-        string serializedTicket = JsonSerializer.Serialize(ticket.ToSerializableObj());
-        
-        IdentityServerServerSideSessions serverSideSession = new IdentityServerServerSideSessions
-        {
-            Key = key,
-            Scheme = ticket.AuthenticationScheme,
-            SubjectId = ticket.Principal.GetSubjectId(),
-            SessionId = ticket.Properties.GetSessionId(),
-            DisplayName = ticket.Principal.FindFirstValue(JwtClaimTypes.Name), //Make configurable?
-            Created = ticket.Properties.IssuedUtc?.UtcDateTime ?? timeProvider.GetUtcNow().UtcDateTime,
-            Renewed = ticket.Properties.IssuedUtc?.UtcDateTime ?? timeProvider.GetUtcNow().UtcDateTime,
-            Expires = ticket.Properties.ExpiresUtc?.UtcDateTime,
-            Data = dataProtector.Protect(serializedTicket),
-        };
-
-        await serverServerSideSessionStore.CreateSession(serverSideSession);
-
-        return serverSideSession;
-    }
-
     /// <inheritdoc />
     public async Task RenewAsync(string key, AuthenticationTicket ticket)
     {
@@ -102,8 +81,6 @@ public class ServerSessionTicketStore(
         string? sessionId = ticket.Properties.GetSessionId();
         trace?.AddTag(TelemetryConstants.TagConstants.Subject, subjectId);
         trace?.AddTag(TelemetryConstants.TagConstants.Session, sessionId);
-        
-        string serializedTicket = JsonSerializer.Serialize(ticket.ToSerializableObj());
 
         existingSession.Scheme = ticket.AuthenticationScheme;
         existingSession.SubjectId = subjectId;
@@ -111,7 +88,7 @@ public class ServerSessionTicketStore(
         existingSession.DisplayName = ticket.Principal.FindFirstValue(JwtClaimTypes.Name);
         existingSession.Renewed = ticket.Properties.IssuedUtc?.UtcDateTime ?? timeProvider.GetUtcNow().UtcDateTime;
         existingSession.Expires = ticket.Properties.ExpiresUtc?.UtcDateTime;
-        existingSession.Data = dataProtector.Protect(serializedTicket);
+        existingSession.Data = ToProtectedDataString(ticket);
 
         await serverServerSideSessionStore.UpdateSession(existingSession);
     }
@@ -134,7 +111,15 @@ public class ServerSessionTicketStore(
 
         try
         {
-            string unprotectedData = dataProtector.Unprotect(existingSession.Data);
+            DataProtectedSessionData? dataProtectedSessionData = JsonSerializer.Deserialize<DataProtectedSessionData>(existingSession.Data, JsonSettings);
+
+            if (dataProtectedSessionData is not { Version: 1 })
+            {
+                logger.LogError("failed retrieving '{SessionKey}', deserialisation failed, incorrect version '{VersionOrNull}'", key, dataProtectedSessionData?.Version);
+                return null;
+            }
+            
+            string unprotectedData = dataProtector.Unprotect(dataProtectedSessionData.Payload);
 
             SerializedAuthenticationTicket? serializedAuthTicket =
                 JsonSerializer.Deserialize<SerializedAuthenticationTicket>(unprotectedData);
@@ -158,5 +143,35 @@ public class ServerSessionTicketStore(
 
         serverServerSideSessionStore.DeleteSession(key);
         return Task.CompletedTask;
+    }
+
+    private async Task<IdentityServerServerSideSessions> StoreNewSession(string key, AuthenticationTicket ticket)
+    {
+        IdentityServerServerSideSessions serverSideSession = new IdentityServerServerSideSessions
+        {
+            Key = key,
+            Scheme = ticket.AuthenticationScheme,
+            SubjectId = ticket.Principal.GetSubjectId(),
+            SessionId = ticket.Properties.GetSessionId(),
+            DisplayName = ticket.Principal.FindFirstValue(JwtClaimTypes.Name), //Make configurable?
+            Created = ticket.Properties.IssuedUtc?.UtcDateTime ?? timeProvider.GetUtcNow().UtcDateTime,
+            Renewed = ticket.Properties.IssuedUtc?.UtcDateTime ?? timeProvider.GetUtcNow().UtcDateTime,
+            Expires = ticket.Properties.ExpiresUtc?.UtcDateTime,
+            Data = ToProtectedDataString(ticket),
+        };
+
+        await serverServerSideSessionStore.CreateSession(serverSideSession);
+
+        return serverSideSession;
+    }
+
+    private string ToProtectedDataString(AuthenticationTicket ticket)
+    {
+        string serializedTicket = JsonSerializer.Serialize(ticket.ToSerializableObj());
+
+        return JsonSerializer.Serialize(new DataProtectedSessionData
+        {
+            Payload = dataProtector.Protect(serializedTicket),
+        }, JsonSettings);
     }
 }

--- a/src/Open.IdentityServer/src/Stores/Default/ServerSessionTicketStore.cs
+++ b/src/Open.IdentityServer/src/Stores/Default/ServerSessionTicketStore.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging;
 using Open.IdentityServer.Extensions;
 using Open.IdentityServer.Models;
+using Open.IdentityServer.Services;
 using Open.IdentityServer.Stores.Serialization;
 
 namespace Open.IdentityServer.Stores;
@@ -23,15 +24,18 @@ namespace Open.IdentityServer.Stores;
 /// <param name="serverServerSideSessionStore"></param>
 /// <param name="dataProtectionProvider"></param>
 /// <param name="timeProvider"></param>
+/// <param name="telemetry"></param>
 /// <param name="logger"></param>
 public class ServerSessionTicketStore(
     IIdentityServerServerSideSessionStore serverServerSideSessionStore,
     IDataProtectionProvider dataProtectionProvider,
     TimeProvider timeProvider,
-    ILogger<ServerSessionTicketStore> logger): ITicketStore
+    ITelemetryService telemetry,
+    ILogger<ServerSessionTicketStore> logger) : ITicketStore
 {
-    private readonly IDataProtector dataProtector = dataProtectionProvider.CreateProtector(DataProtectionConstants.ServerSideTicketStorePurpose);
-    
+    private readonly IDataProtector dataProtector =
+        dataProtectionProvider.CreateProtector(DataProtectionConstants.ServerSideTicketStorePurpose);
+
     /// <summary>
     /// 
     /// </summary>
@@ -43,14 +47,23 @@ public class ServerSessionTicketStore(
     /// <inheritdoc />
     public async Task<string> StoreAsync(AuthenticationTicket ticket)
     {
-        var serializedTicket = JsonSerializer.Serialize(ticket.ToSerializableObj());
-        
-        var serverSideSession = new IdentityServerServerSideSessions
+        using ITrace? trace = telemetry.Trace(TelemetryConstants.TraceCategories.Stores, this);
+
+        string serializedTicket = JsonSerializer.Serialize(ticket.ToSerializableObj());
+
+        string key = Guid.NewGuid().ToString();
+        string? subjectId = ticket.Principal.GetSubjectId();
+        string? sessionId = ticket.Properties.GetSessionId();
+        trace?.AddTag(TelemetryConstants.TagConstants.Key, key);
+        trace?.AddTag(TelemetryConstants.TagConstants.Subject, subjectId);
+        trace?.AddTag(TelemetryConstants.TagConstants.Session, sessionId);
+
+        IdentityServerServerSideSessions serverSideSession = new IdentityServerServerSideSessions
         {
-            Key = Guid.NewGuid().ToString(),
+            Key = key,
             Scheme = ticket.AuthenticationScheme,
-            SubjectId = ticket.Principal.GetSubjectId(),
-            SessionId = ticket.Properties.GetSessionId(),
+            SubjectId = subjectId,
+            SessionId = sessionId,
             DisplayName = ticket.Principal.FindFirstValue(JwtClaimTypes.Name), //Make configurable?
             Created = ticket.Properties.IssuedUtc?.UtcDateTime ?? timeProvider.GetUtcNow().UtcDateTime,
             Renewed = ticket.Properties.IssuedUtc?.UtcDateTime ?? timeProvider.GetUtcNow().UtcDateTime,
@@ -66,21 +79,29 @@ public class ServerSessionTicketStore(
     /// <inheritdoc />
     public async Task RenewAsync(string key, AuthenticationTicket ticket)
     {
+        using ITrace? trace = telemetry.Trace(TelemetryConstants.TraceCategories.Stores, this);
+        trace?.AddTag(TelemetryConstants.TagConstants.Key, key);
+
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
-        
-        var existingSession = await serverServerSideSessionStore.GetSession(key);
+
+        IdentityServerServerSideSessions? existingSession = await serverServerSideSessionStore.GetSession(key);
 
         if (existingSession == null)
         {
             logger.LogError("failed renewing '{SessionKey}' session in database, session with key doesn't exists", key);
             return;
         }
-
-        var serializedTicket = JsonSerializer.Serialize(ticket.ToSerializableObj());
         
+        string? subjectId = ticket.Principal.GetSubjectId();
+        string? sessionId = ticket.Properties.GetSessionId();
+        trace?.AddTag(TelemetryConstants.TagConstants.Subject, subjectId);
+        trace?.AddTag(TelemetryConstants.TagConstants.Session, sessionId);
+        
+        string serializedTicket = JsonSerializer.Serialize(ticket.ToSerializableObj());
+
         existingSession.Scheme = ticket.AuthenticationScheme;
-        existingSession.SubjectId = ticket.Principal.GetSubjectId();
-        existingSession.SessionId = ticket.Properties.GetSessionId();
+        existingSession.SubjectId = subjectId;
+        existingSession.SessionId = sessionId;
         existingSession.DisplayName = ticket.Principal.FindFirstValue(JwtClaimTypes.Name);
         existingSession.Renewed = ticket.Properties.IssuedUtc?.UtcDateTime ?? timeProvider.GetUtcNow().UtcDateTime;
         existingSession.Expires = ticket.Properties.ExpiresUtc?.UtcDateTime;
@@ -92,10 +113,13 @@ public class ServerSessionTicketStore(
     /// <inheritdoc />
     public async Task<AuthenticationTicket?> RetrieveAsync(string key)
     {
+        using ITrace? trace = telemetry.Trace(TelemetryConstants.TraceCategories.Stores, this);
+        trace?.AddTag(TelemetryConstants.TagConstants.Key, key);
+
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
-        
-        var existingSession = await serverServerSideSessionStore.GetSession(key);
-        
+
+        IdentityServerServerSideSessions? existingSession = await serverServerSideSessionStore.GetSession(key);
+
         if (existingSession == null)
         {
             logger.LogInformation("session with key '{SessionKey}' doesn't exist", key);
@@ -104,9 +128,10 @@ public class ServerSessionTicketStore(
 
         try
         {
-            var unprotectedData = dataProtector.Unprotect(existingSession.Data);
+            string unprotectedData = dataProtector.Unprotect(existingSession.Data);
 
-            SerializedAuthenticationTicket? serializedAuthTicket = JsonSerializer.Deserialize<SerializedAuthenticationTicket>(unprotectedData);
+            SerializedAuthenticationTicket? serializedAuthTicket =
+                JsonSerializer.Deserialize<SerializedAuthenticationTicket>(unprotectedData);
 
             return serializedAuthTicket?.ToAuthTicket();
         }
@@ -120,8 +145,11 @@ public class ServerSessionTicketStore(
     /// <inheritdoc />
     public Task RemoveAsync(string key)
     {
+        using ITrace? trace = telemetry.Trace(TelemetryConstants.TraceCategories.Stores, this);
+        trace?.AddTag(TelemetryConstants.TagConstants.Key, key);
+
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
-        
+
         serverServerSideSessionStore.DeleteSession(key);
         return Task.CompletedTask;
     }

--- a/src/Open.IdentityServer/src/Stores/Default/ServerSessionTicketStore.cs
+++ b/src/Open.IdentityServer/src/Stores/Default/ServerSessionTicketStore.cs
@@ -49,21 +49,26 @@ public class ServerSessionTicketStore(
     {
         using ITrace? trace = telemetry.Trace(TelemetryConstants.TraceCategories.Stores, this);
 
-        string serializedTicket = JsonSerializer.Serialize(ticket.ToSerializableObj());
-
         string key = Guid.NewGuid().ToString();
-        string? subjectId = ticket.Principal.GetSubjectId();
-        string? sessionId = ticket.Properties.GetSessionId();
         trace?.AddTag(TelemetryConstants.TagConstants.Key, key);
-        trace?.AddTag(TelemetryConstants.TagConstants.Subject, subjectId);
-        trace?.AddTag(TelemetryConstants.TagConstants.Session, sessionId);
+        
+        IdentityServerServerSideSessions session = await StoreNewSession(key, ticket);
+        trace?.AddTag(TelemetryConstants.TagConstants.Subject, session.SubjectId);
+        trace?.AddTag(TelemetryConstants.TagConstants.Session, session.SessionId);
 
+        return session.Key;
+    }
+
+    private async Task<IdentityServerServerSideSessions> StoreNewSession(string key, AuthenticationTicket ticket)
+    {
+        string serializedTicket = JsonSerializer.Serialize(ticket.ToSerializableObj());
+        
         IdentityServerServerSideSessions serverSideSession = new IdentityServerServerSideSessions
         {
             Key = key,
             Scheme = ticket.AuthenticationScheme,
-            SubjectId = subjectId,
-            SessionId = sessionId,
+            SubjectId = ticket.Principal.GetSubjectId(),
+            SessionId = ticket.Properties.GetSessionId(),
             DisplayName = ticket.Principal.FindFirstValue(JwtClaimTypes.Name), //Make configurable?
             Created = ticket.Properties.IssuedUtc?.UtcDateTime ?? timeProvider.GetUtcNow().UtcDateTime,
             Renewed = ticket.Properties.IssuedUtc?.UtcDateTime ?? timeProvider.GetUtcNow().UtcDateTime,
@@ -73,7 +78,7 @@ public class ServerSessionTicketStore(
 
         await serverServerSideSessionStore.CreateSession(serverSideSession);
 
-        return serverSideSession.Key;
+        return serverSideSession;
     }
 
     /// <inheritdoc />
@@ -88,7 +93,8 @@ public class ServerSessionTicketStore(
 
         if (existingSession == null)
         {
-            logger.LogError("failed renewing '{SessionKey}' session in database, session with key doesn't exists", key);
+            logger.LogInformation("failed renewing '{SessionKey}' session in database, session with key doesn't exists", key);
+            await StoreNewSession(key, ticket);
             return;
         }
         

--- a/src/Open.IdentityServer/src/Stores/Default/ServerSessionTicketStore.cs
+++ b/src/Open.IdentityServer/src/Stores/Default/ServerSessionTicketStore.cs
@@ -20,13 +20,14 @@ using Open.IdentityServer.Stores.Serialization;
 namespace Open.IdentityServer.Stores;
 
 /// <summary>
-/// 
+/// Implementation of <see cref="ITicketStore"/> for storing <see cref="AuthenticationTicket"/> for the server side sessions
+/// implementation in Open.IdentityServer
 /// </summary>
 /// <param name="serverServerSideSessionStore"></param>
-/// <param name="dataProtectionProvider"></param>
-/// <param name="timeProvider"></param>
-/// <param name="telemetry"></param>
-/// <param name="logger"></param>
+/// <param name="dataProtectionProvider">data prtection provider</param>
+/// <param name="timeProvider">time provider</param>
+/// <param name="telemetry">telemetry service</param>
+/// <param name="logger">the logger</param>
 public class ServerSessionTicketStore(
     IIdentityServerServerSideSessionStore serverServerSideSessionStore,
     IDataProtectionProvider dataProtectionProvider,
@@ -38,7 +39,7 @@ public class ServerSessionTicketStore(
         dataProtectionProvider.CreateProtector(DataProtectionConstants.ServerSideTicketStorePurpose);
 
     /// <summary>
-    /// 
+    /// <see cref="JsonSerializerOptions"/> to be used for storing server side sessions
     /// </summary>
     public static readonly JsonSerializerOptions JsonSettings = new()
     {

--- a/src/Open.IdentityServer/src/Stores/Default/ServerSessionTicketStore.cs
+++ b/src/Open.IdentityServer/src/Stores/Default/ServerSessionTicketStore.cs
@@ -1,0 +1,43 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Logging;
+
+namespace Open.IdentityServer.Stores;
+
+/// <summary>
+/// 
+/// </summary>
+/// <param name="dataProtectionProvider"></param>
+/// <param name="logger"></param>
+public class ServerSessionTicketStore(
+    IDataProtectionProvider dataProtectionProvider,
+    ILogger<ServerSessionTicketStore> logger): ITicketStore
+{
+    private IDataProtector dataProtector = dataProtectionProvider?.CreateProtector(DataProtectionConstants.ServerSideTicketStorePurpose);
+
+    /// <inheritdoc />
+    public Task<string> StoreAsync(AuthenticationTicket ticket)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public Task RenewAsync(string key, AuthenticationTicket ticket)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public Task<AuthenticationTicket> RetrieveAsync(string key)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public Task RemoveAsync(string key)
+    {
+        throw new System.NotImplementedException();
+    }
+}

--- a/src/Open.IdentityServer/src/Stores/Default/ServerSessionTicketStore.cs
+++ b/src/Open.IdentityServer/src/Stores/Default/ServerSessionTicketStore.cs
@@ -1,43 +1,125 @@
+#nullable enable
+
+using System;
+using System.Security.Claims;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging;
+using Open.IdentityServer.Extensions;
+using Open.IdentityServer.Models;
+using Open.IdentityServer.Stores.Serialization;
 
 namespace Open.IdentityServer.Stores;
 
 /// <summary>
 /// 
 /// </summary>
+/// <param name="serverServerSideSessionStore"></param>
 /// <param name="dataProtectionProvider"></param>
+/// <param name="timeProvider"></param>
 /// <param name="logger"></param>
 public class ServerSessionTicketStore(
+    IIdentityServerServerSideSessionStore serverServerSideSessionStore,
     IDataProtectionProvider dataProtectionProvider,
+    TimeProvider timeProvider,
     ILogger<ServerSessionTicketStore> logger): ITicketStore
 {
-    private IDataProtector dataProtector = dataProtectionProvider?.CreateProtector(DataProtectionConstants.ServerSideTicketStorePurpose);
+    private readonly IDataProtector dataProtector = dataProtectionProvider.CreateProtector(DataProtectionConstants.ServerSideTicketStorePurpose);
+    
+    /// <summary>
+    /// 
+    /// </summary>
+    public static readonly JsonSerializerOptions JsonSettings = new()
+    {
+        IncludeFields = true,
+    };
 
     /// <inheritdoc />
-    public Task<string> StoreAsync(AuthenticationTicket ticket)
+    public async Task<string> StoreAsync(AuthenticationTicket ticket)
     {
-        throw new System.NotImplementedException();
+        var serializedTicket = JsonSerializer.Serialize(ticket.ToSerializableObj());
+        
+        var serverSideSession = new IdentityServerServerSideSessions
+        {
+            Key = Guid.NewGuid().ToString(),
+            Scheme = ticket.AuthenticationScheme,
+            SubjectId = ticket.Principal.GetSubjectId(),
+            SessionId = ticket.Properties.GetSessionId(),
+            DisplayName = ticket.Principal.FindFirstValue(JwtClaimTypes.Name), //Make configurable?
+            Created = ticket.Properties.IssuedUtc?.UtcDateTime ?? timeProvider.GetUtcNow().UtcDateTime,
+            Renewed = ticket.Properties.IssuedUtc?.UtcDateTime ?? timeProvider.GetUtcNow().UtcDateTime,
+            Expires = ticket.Properties.ExpiresUtc?.UtcDateTime,
+            Data = dataProtector.Protect(serializedTicket),
+        };
+
+        await serverServerSideSessionStore.CreateSession(serverSideSession);
+
+        return serverSideSession.Key;
     }
 
     /// <inheritdoc />
-    public Task RenewAsync(string key, AuthenticationTicket ticket)
+    public async Task RenewAsync(string key, AuthenticationTicket ticket)
     {
-        throw new System.NotImplementedException();
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        
+        var existingSession = await serverServerSideSessionStore.GetSession(key);
+
+        if (existingSession == null)
+        {
+            logger.LogError("failed renewing '{SessionKey}' session in database, session with key doesn't exists", key);
+            return;
+        }
+
+        var serializedTicket = JsonSerializer.Serialize(ticket.ToSerializableObj());
+        
+        existingSession.Scheme = ticket.AuthenticationScheme;
+        existingSession.SubjectId = ticket.Principal.GetSubjectId();
+        existingSession.SessionId = ticket.Properties.GetSessionId();
+        existingSession.DisplayName = ticket.Principal.FindFirstValue(JwtClaimTypes.Name);
+        existingSession.Renewed = ticket.Properties.IssuedUtc?.UtcDateTime ?? timeProvider.GetUtcNow().UtcDateTime;
+        existingSession.Expires = ticket.Properties.ExpiresUtc?.UtcDateTime;
+        existingSession.Data = dataProtector.Protect(serializedTicket);
+
+        await serverServerSideSessionStore.UpdateSession(existingSession);
     }
 
     /// <inheritdoc />
-    public Task<AuthenticationTicket> RetrieveAsync(string key)
+    public async Task<AuthenticationTicket?> RetrieveAsync(string key)
     {
-        throw new System.NotImplementedException();
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        
+        var existingSession = await serverServerSideSessionStore.GetSession(key);
+        
+        if (existingSession == null)
+        {
+            logger.LogInformation("session with key '{SessionKey}' doesn't exist", key);
+            return null;
+        }
+
+        try
+        {
+            var unprotectedData = dataProtector.Unprotect(existingSession.Data);
+
+            SerializedAuthenticationTicket? serializedAuthTicket = JsonSerializer.Deserialize<SerializedAuthenticationTicket>(unprotectedData);
+
+            return serializedAuthTicket?.ToAuthTicket();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "failed retrieving '{SessionKey}' session in database", key);
+            return null;
+        }
     }
 
     /// <inheritdoc />
     public Task RemoveAsync(string key)
     {
-        throw new System.NotImplementedException();
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        
+        serverServerSideSessionStore.DeleteSession(key);
+        return Task.CompletedTask;
     }
 }

--- a/src/Open.IdentityServer/src/Stores/Default/ServerSessionTicketStore.cs
+++ b/src/Open.IdentityServer/src/Stores/Default/ServerSessionTicketStore.cs
@@ -73,19 +73,14 @@ public class ServerSessionTicketStore(
 
         if (existingSession == null)
         {
-            logger.LogInformation("failed renewing '{SessionKey}' session in database, session with key doesn't exists", key);
+            logger.LogWarning("failed renewing '{SessionKey}' session in database, session with key doesn't exist", key);
             await StoreNewSession(key, ticket);
             return;
         }
-        
-        string? subjectId = ticket.Principal.GetSubjectId();
-        string? sessionId = ticket.Properties.GetSessionId();
-        trace?.AddTag(TelemetryConstants.TagConstants.Subject, subjectId);
-        trace?.AddTag(TelemetryConstants.TagConstants.Session, sessionId);
 
         existingSession.Scheme = ticket.AuthenticationScheme;
-        existingSession.SubjectId = subjectId;
-        existingSession.SessionId = sessionId;
+        existingSession.SubjectId = ticket.Principal.GetSubjectId();
+        existingSession.SessionId = ticket.Properties.GetSessionId();
         existingSession.DisplayName = ticket.Principal.FindFirstValue(JwtClaimTypes.Name);
         existingSession.Renewed = ticket.Properties.IssuedUtc?.UtcDateTime ?? timeProvider.GetUtcNow().UtcDateTime;
         existingSession.Expires = ticket.Properties.ExpiresUtc?.UtcDateTime;
@@ -106,7 +101,7 @@ public class ServerSessionTicketStore(
 
         if (existingSession == null)
         {
-            logger.LogInformation("session with key '{SessionKey}' doesn't exist", key);
+            logger.LogWarning("session with key '{SessionKey}' doesn't exist", key);
             return null;
         }
 
@@ -138,7 +133,6 @@ public class ServerSessionTicketStore(
     public Task RemoveAsync(string key)
     {
         using ITrace? trace = telemetry.Trace(TelemetryConstants.TraceCategories.Stores, this);
-        trace?.AddTag(TelemetryConstants.TagConstants.Key, key);
 
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
 

--- a/src/Open.IdentityServer/src/Stores/InMemory/InMemorySessionStore.cs
+++ b/src/Open.IdentityServer/src/Stores/InMemory/InMemorySessionStore.cs
@@ -1,0 +1,54 @@
+#nullable enable
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Open.IdentityServer.Models;
+
+namespace Open.IdentityServer.Stores;
+
+/// <summary>
+/// In-memory server-side session store
+/// </summary>
+public class InMemorySessionStore(): IIdentityServerServerSideSessionStore
+{
+    private readonly ConcurrentDictionary<string, IdentityServerServerSideSessions> repo = new();
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="seedData"></param>
+    public InMemorySessionStore(IDictionary<string, IdentityServerServerSideSessions> seedData): this()
+    {
+        repo = new ConcurrentDictionary<string, IdentityServerServerSideSessions>(seedData.ToList() ?? []);
+    }
+    
+    /// <inheritdoc />
+    public Task<IdentityServerServerSideSessions?> GetSession(string key)
+    {
+        repo.TryGetValue(key, out IdentityServerServerSideSessions? value);
+        return Task.FromResult(value);
+    }
+
+    /// <inheritdoc />
+    public Task CreateSession(IdentityServerServerSideSessions session)
+    {
+        repo[session.Key] = session;
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task UpdateSession(IdentityServerServerSideSessions session)
+    {
+        repo[session.Key] = session;
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task DeleteSession(string key)
+    {
+        repo.TryRemove(key, out IdentityServerServerSideSessions? value);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Open.IdentityServer/src/Stores/InMemory/InMemorySessionStore.cs
+++ b/src/Open.IdentityServer/src/Stores/InMemory/InMemorySessionStore.cs
@@ -17,15 +17,6 @@ namespace Open.IdentityServer.Stores;
 public class InMemorySessionStore(): IIdentityServerServerSideSessionStore
 {
     private readonly ConcurrentDictionary<string, IdentityServerServerSideSessions> repo = new();
-
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="seedData"></param>
-    public InMemorySessionStore(IDictionary<string, IdentityServerServerSideSessions> seedData): this()
-    {
-        repo = new ConcurrentDictionary<string, IdentityServerServerSideSessions>(seedData.ToList() ?? []);
-    }
     
     /// <inheritdoc />
     public Task<IdentityServerServerSideSessions?> GetSession(string key)

--- a/src/Open.IdentityServer/src/Stores/InMemory/InMemorySessionStore.cs
+++ b/src/Open.IdentityServer/src/Stores/InMemory/InMemorySessionStore.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
 #nullable enable
 
 using System.Collections.Concurrent;

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
@@ -1,4 +1,5 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Modified by Rock Solid Knowledge Ltd. Copyright in modifications 2026, Rock Solid Knowledge Ltd.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 #nullable enable

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
@@ -75,6 +75,9 @@ public class IdentityServerPipeline
     public event Action<IApplicationBuilder> OnPostConfigure = app => { };
 
     public Func<HttpContext, Task<bool>>? OnFederatedSignout;
+    
+    // Enableable Features
+    public bool EnableServerSideSessions { get; set; }
 
     public void Initialize(string? basePath = null, bool enableLogging = false)
     {
@@ -131,7 +134,7 @@ public class IdentityServerPipeline
             return handler;
         });
 
-        services.AddIdentityServer(options =>
+        var idsBuilder = services.AddIdentityServer(options =>
             {
                 Options = options;
 
@@ -149,6 +152,11 @@ public class IdentityServerPipeline
             .AddInMemoryApiScopes(ApiScopes)
             .AddTestUsers(Users)
             .AddDeveloperSigningCredential(persistKey: false);
+
+        if (EnableServerSideSessions)
+        {
+            idsBuilder.AddServerSideSessions();
+        }
 
         services.AddHttpClient(IdentityServerConstants.HttpClients.BackChannelLogoutHttpClient)
             .AddHttpMessageHandler(() => BackChannelMessageHandler);

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
@@ -27,6 +27,8 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.Extensions.Options;
 
 namespace IdentityServer.IntegrationTests.Common;
 
@@ -52,6 +54,8 @@ public class IdentityServerPipeline
 
     public const string FederatedSignOutPath = "/signout-oidc";
     public const string FederatedSignOutUrl = BaseUrl + FederatedSignOutPath;
+
+    public const string AuthCookieSessionIdClaimType = "Microsoft.AspNetCore.Authentication.Cookies-SessionId";
 
     public IdentityServerOptions? Options { get; set; }
     public List<Client> Clients { get; set; } = new List<Client>();
@@ -299,7 +303,7 @@ public class IdentityServerPipeline
 
         Subject = subject;
         await BrowserClient.GetAsync(LoginPage);
-
+        
         BrowserClient.AllowAutoRedirect = old;
     }
 
@@ -319,6 +323,26 @@ public class IdentityServerPipeline
     public Cookie GetSessionCookie()
     {
         return BrowserClient!.GetCookie(BaseUrl, IdentityServerConstants.DefaultCheckSessionCookieName);
+    }
+
+    public Cookie GetLoginCookie()
+    {
+        return BrowserClient!.GetCookie(BaseUrl, IdentityServerConstants.DefaultCookieAuthenticationScheme);
+    }
+
+    public string? GetTicketStoreKeyFromAuthCookie()
+    {
+        var authCookie = GetLoginCookie();
+        if (authCookie == null || string.IsNullOrWhiteSpace(authCookie.Value))
+        {
+            return null;
+        }
+
+        var optionsMonitor = Server!.Services.GetRequiredService<IOptionsMonitor<CookieAuthenticationOptions>>();
+        var cookieOptions = optionsMonitor.Get(IdentityServerConstants.DefaultCookieAuthenticationScheme);
+
+        var ticket = cookieOptions.TicketDataFormat.Unprotect(authCookie.Value);
+        return ticket?.Principal?.FindFirst(AuthCookieSessionIdClaimType)?.Value;
     }
 
     public string CreateAuthorizeUrl(

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/ServerSideSessionTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/ServerSideSessionTests.cs
@@ -1,0 +1,6 @@
+namespace IdentityServer.IntegrationTests.Endpoints.Authorize;
+
+public class ServerSideSessionTests
+{
+    
+}

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/ServerSideSessionTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/ServerSideSessionTests.cs
@@ -1,6 +1,0 @@
-namespace IdentityServer.IntegrationTests.Endpoints.Authorize;
-
-public class ServerSideSessionTests
-{
-    
-}

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/CheckSession/CheckSessionTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/CheckSession/CheckSessionTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-
 using System.Net;
 using System.Threading.Tasks;
 using AwesomeAssertions;

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/EndSession/EndSessionServerSideSessionTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/EndSession/EndSessionServerSideSessionTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
 #nullable enable
 
 using System.Collections.Generic;
@@ -106,7 +109,7 @@ public class EndSessionServerSideSessionTests
         storedSessionPreEndSession.SessionId.Should().Be(sessionCookie.Value);
         storedSessionPreEndSession.SubjectId.Should().Be("bob");
         
-        await _mockPipeline.BrowserClient.GetAsync(IdentityServerPipeline.EndSessionEndpoint, 
+        await _mockPipeline.BrowserClient!.GetAsync(IdentityServerPipeline.EndSessionEndpoint, 
             TestContext.Current.CancellationToken);
 
         _mockPipeline.LogoutWasCalled.Should().BeTrue();

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/EndSession/EndSessionServerSideSessionTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/EndSession/EndSessionServerSideSessionTests.cs
@@ -1,27 +1,31 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
-
+#nullable enable
 
 using System.Collections.Generic;
+using System.Net;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using AwesomeAssertions;
 using IdentityServer.IntegrationTests.Common;
+using Microsoft.Extensions.DependencyInjection;
 using Open.IdentityServer.Models;
+using Open.IdentityServer.Stores;
 using Open.IdentityServer.Test;
 using Xunit;
 
-namespace IdentityServer.IntegrationTests.Endpoints.Authorize;
+namespace Open.IdentityServer.IntegrationTests.Endpoints.Login;
 
-public class SessionIdTests
+public class EndSessionServerSideSessionTests
 {
-    private const string Category = "SessionIdTests";
+    private const string Category = "EndSessionServerSideSessionTests";
 
     private IdentityServerPipeline _mockPipeline = new IdentityServerPipeline();
+    private IIdentityServerServerSideSessionStore? sessionStore = null;
 
-    public SessionIdTests()
+    public EndSessionServerSideSessionTests()
     {
-        _mockPipeline.Clients.AddRange(new Client[] {
+        _mockPipeline.EnableServerSideSessions = true;
+        
+        _mockPipeline.Clients.AddRange([
             new Client
             {
                 ClientId = "client1",
@@ -40,32 +44,32 @@ public class SessionIdTests
                 RedirectUris = new List<string> { "https://client2/callback" },
                 AllowAccessTokensViaBrowser = true
             }
-        });
+        ]);
 
         _mockPipeline.Users.Add(new TestUser
         {
             SubjectId = "bob",
             Username = "bob",
-            Claims = new Claim[]
-            {
+            Claims =
+            [
                 new Claim("name", "Bob Loblaw"),
                 new Claim("email", "bob@loblaw.com"),
                 new Claim("role", "Attorney")
-            }
+            ]
         });
 
-        _mockPipeline.IdentityScopes.AddRange(new IdentityResource[] {
+        _mockPipeline.IdentityScopes.AddRange([
             new IdentityResources.OpenId(),
             new IdentityResources.Profile(),
             new IdentityResources.Email()
-        });
-        _mockPipeline.ApiResources.AddRange(new ApiResource[] {
+        ]);
+        _mockPipeline.ApiResources.AddRange([
             new ApiResource
             {
                 Name = "api",
             }
-        });
-        _mockPipeline.ApiScopes.AddRange(new ApiScope[] {
+        ]);
+        _mockPipeline.ApiScopes.AddRange([
             new ApiScope
             {
                 Name = "api1"
@@ -74,25 +78,41 @@ public class SessionIdTests
             {
                 Name = "api2"
             }
-        });
+        ]);
+        
+        _mockPipeline.OnPreConfigure += app =>
+        {
+            sessionStore = app.ApplicationServices.GetRequiredService<IIdentityServerServerSideSessionStore>();
+        };
 
         _mockPipeline.Initialize();
     }
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task session_id_should_be_reissued_if_session_cookie_absent()
+    public async Task EndSession_ShouldRemoveSession()
     {
+        sessionStore.Should().NotBeNull();
+        
         await _mockPipeline.LoginAsync("bob");
-        var sid1 = _mockPipeline.GetSessionCookie().Value;
-        sid1.Should().NotBeNull();
 
-        _mockPipeline.RemoveSessionCookie();
+        Cookie sessionCookie = _mockPipeline.GetSessionCookie();
+        
+        var authKey = _mockPipeline.GetTicketStoreKeyFromAuthCookie();
+        authKey.Should().NotBeNull();
+        
+        var storedSessionPreEndSession = await sessionStore.GetSession(authKey);
+        storedSessionPreEndSession.Should().NotBeNull();
+        storedSessionPreEndSession.SessionId.Should().Be(sessionCookie.Value);
+        storedSessionPreEndSession.SubjectId.Should().Be("bob");
+        
+        await _mockPipeline.BrowserClient.GetAsync(IdentityServerPipeline.EndSessionEndpoint, 
+            TestContext.Current.CancellationToken);
 
-        await _mockPipeline.BrowserClient.GetAsync(IdentityServerPipeline.DiscoveryEndpoint
-            , TestContext.Current.CancellationToken);
-
-        var sid2 = _mockPipeline.GetSessionCookie().Value;
-        sid2.Should().Be(sid1);
+        _mockPipeline.LogoutWasCalled.Should().BeTrue();
+        _mockPipeline.LogoutRequest.Should().NotBeNull();
+        
+        var storedSessionPostEndSession = await sessionStore.GetSession(authKey);
+        storedSessionPostEndSession.Should().BeNull();
     }
 }

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Login/LoginServerSideSessionTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Login/LoginServerSideSessionTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
 #nullable enable
 
 using System.Collections.Generic;

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Login/LoginServerSideSessionTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Login/LoginServerSideSessionTests.cs
@@ -1,0 +1,149 @@
+#nullable enable
+
+using System.Collections.Generic;
+using System.Net;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using IdentityServer.IntegrationTests.Common;
+using Microsoft.Extensions.DependencyInjection;
+using Open.IdentityServer.Models;
+using Open.IdentityServer.Stores;
+using Open.IdentityServer.Test;
+using Xunit;
+
+namespace Open.IdentityServer.IntegrationTests.Endpoints.Login;
+
+public class LoginServerSideSessionTests
+{
+    private const string Category = "LoginServerSideSessionTests";
+
+    private IdentityServerPipeline _mockPipeline = new IdentityServerPipeline();
+    private IIdentityServerServerSideSessionStore? sessionStore = null;
+
+    public LoginServerSideSessionTests()
+    {
+        _mockPipeline.EnableServerSideSessions = true;
+        
+        _mockPipeline.Clients.AddRange([
+            new Client
+            {
+                ClientId = "client1",
+                AllowedGrantTypes = GrantTypes.Implicit,
+                RequireConsent = false,
+                AllowedScopes = new List<string> { "openid", "profile" },
+                RedirectUris = new List<string> { "https://client1/callback" },
+                AllowAccessTokensViaBrowser = true
+            },
+            new Client
+            {
+                ClientId = "client2",
+                AllowedGrantTypes = GrantTypes.Implicit,
+                RequireConsent = true,
+                AllowedScopes = new List<string> { "openid", "profile", "api1", "api2" },
+                RedirectUris = new List<string> { "https://client2/callback" },
+                AllowAccessTokensViaBrowser = true
+            }
+        ]);
+
+        _mockPipeline.Users.Add(new TestUser
+        {
+            SubjectId = "bob",
+            Username = "bob",
+            Claims =
+            [
+                new Claim("name", "Bob Loblaw"),
+                new Claim("email", "bob@loblaw.com"),
+                new Claim("role", "Attorney")
+            ]
+        });
+
+        _mockPipeline.Users.Add(new TestUser
+        {
+            SubjectId = "alice",
+            Username = "alice",
+            Claims =
+            [
+                new Claim("name", "Alice Smith"),
+                new Claim("alice", "alice@smith.com"),
+                new Claim("role", "Attorney")
+            ]
+        });
+
+        _mockPipeline.IdentityScopes.AddRange([
+            new IdentityResources.OpenId(),
+            new IdentityResources.Profile(),
+            new IdentityResources.Email()
+        ]);
+        _mockPipeline.ApiResources.AddRange([
+            new ApiResource
+            {
+                Name = "api",
+            }
+        ]);
+        _mockPipeline.ApiScopes.AddRange([
+            new ApiScope
+            {
+                Name = "api1"
+            },
+            new ApiScope
+            {
+                Name = "api2"
+            }
+        ]);
+        
+        _mockPipeline.OnPreConfigure += app =>
+        {
+            sessionStore = app.ApplicationServices.GetRequiredService<IIdentityServerServerSideSessionStore>();
+        };
+
+        _mockPipeline.Initialize();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task Login_ShouldCreateSessionInServerStore()
+    {
+        sessionStore.Should().NotBeNull();
+        
+        await _mockPipeline.LoginAsync("bob");
+
+        Cookie sessionCookie = _mockPipeline.GetSessionCookie();
+
+        var authKey = _mockPipeline.GetTicketStoreKeyFromAuthCookie();
+        authKey.Should().NotBeNull();
+        
+        var storedSession = await sessionStore.GetSession(authKey);
+        storedSession.Should().NotBeNull();
+        storedSession.SessionId.Should().Be(sessionCookie.Value);
+        storedSession.SubjectId.Should().Be("bob");
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task Login_WhenUserChangfes_ShouldUpdateSessionInServerStore()
+    {
+        sessionStore.Should().NotBeNull();
+        
+        await _mockPipeline.LoginAsync("bob");
+
+        Cookie originalSessionCookie = _mockPipeline.GetSessionCookie();
+
+        var authKey = _mockPipeline.GetTicketStoreKeyFromAuthCookie();
+        authKey.Should().NotBeNull();
+        
+        var originalSession = await sessionStore.GetSession(authKey);
+        originalSession.Should().NotBeNull();
+        originalSession.SessionId.Should().Be(originalSessionCookie.Value);
+        originalSession.SubjectId.Should().Be("bob");
+        
+        await _mockPipeline.LoginAsync("alice");
+
+        Cookie newSessionCookie = _mockPipeline.GetSessionCookie();
+        
+        var updatedSession = await sessionStore.GetSession(authKey);
+        updatedSession.Should().NotBeNull();
+        updatedSession.SessionId.Should().Be(newSessionCookie.Value);
+        updatedSession.SubjectId.Should().Be("alice");
+    }
+}

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Configuration/DependencyInjection/BuilderExtensions/AdditionalTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Configuration/DependencyInjection/BuilderExtensions/AdditionalTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Open.IdentityServer.Configuration;
+using Open.IdentityServer.Models;
+using Open.IdentityServer.Stores;
+using Xunit;
+
+namespace Open.IdentityServer.UnitTests.Configuration.DependencyInjection;
+
+public class AdditionalTests
+{
+    private IServiceCollection serviceCollection = new ServiceCollection();
+    
+    [Fact]
+    public void AddServerSideSessions_WhenNoStoreConfigured_ShouldConfigureServerSideSessionServicesWithInMemoryStore()
+    {
+        IIdentityServerBuilder builder = new IdentityServerBuilder(serviceCollection);
+
+        builder.AddServerSideSessions();
+        
+        serviceCollection.Should().ContainSingle(d =>
+            d.ServiceType == typeof(IPostConfigureOptions<CookieAuthenticationOptions>) &&
+            d.ImplementationType == typeof(PostConfigureSessionStoreCookieAuthOptions) &&
+            d.Lifetime == ServiceLifetime.Singleton);
+        
+        serviceCollection.Should().ContainSingle(d =>
+            d.ServiceType == typeof(ITicketStore) &&
+            d.ImplementationType == typeof(ServerSessionTicketStore) &&
+            d.Lifetime == ServiceLifetime.Scoped);
+        
+        serviceCollection.Should().ContainSingle(d =>
+            d.ServiceType == typeof(IIdentityServerServerSideSessionStore) &&
+            d.ImplementationType == typeof(InMemorySessionStore) &&
+            d.Lifetime == ServiceLifetime.Singleton);
+    }
+    
+    [Fact]
+    public void AddServerSideSessions_WhenStoreConfigured_ShouldConfigureServerSideSessionServicesWithoutInMemoryStore()
+    {
+        IIdentityServerBuilder builder = new IdentityServerBuilder(serviceCollection);
+
+        serviceCollection.AddSingleton<IIdentityServerServerSideSessionStore, FakeIdentityServerServerSideSessionStore>();
+
+        builder.AddServerSideSessions();
+        
+        serviceCollection.Should().ContainSingle(d =>
+            d.ServiceType == typeof(IPostConfigureOptions<CookieAuthenticationOptions>) &&
+            d.ImplementationType == typeof(PostConfigureSessionStoreCookieAuthOptions) &&
+            d.Lifetime == ServiceLifetime.Singleton);
+        
+        serviceCollection.Should().ContainSingle(d =>
+            d.ServiceType == typeof(ITicketStore) &&
+            d.ImplementationType == typeof(ServerSessionTicketStore) &&
+            d.Lifetime == ServiceLifetime.Scoped);
+        
+        serviceCollection.Should().NotContain(d =>
+            d.ServiceType == typeof(IIdentityServerServerSideSessionStore) &&
+            d.ImplementationType == typeof(InMemorySessionStore) &&
+            d.Lifetime == ServiceLifetime.Singleton);
+    }
+}
+
+public class FakeIdentityServerServerSideSessionStore: IIdentityServerServerSideSessionStore
+{
+    public Task<IdentityServerServerSideSessions> GetSession(string key)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public Task CreateSession(IdentityServerServerSideSessions session)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public Task UpdateSession(IdentityServerServerSideSessions session)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public Task DeleteSession(string key)
+    {
+        throw new System.NotImplementedException();
+    }
+}

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Configuration/PostConfigureSessionStoreCookieAuthOptionsTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Configuration/PostConfigureSessionStoreCookieAuthOptionsTests.cs
@@ -1,0 +1,109 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.Extensions.Options;
+using Moq;
+using Open.IdentityServer.Configuration;
+using Xunit;
+using AuthenticationOptions = Microsoft.AspNetCore.Authentication.AuthenticationOptions;
+
+namespace Open.IdentityServer.UnitTests.Configuration;
+
+public class PostConfigureSessionStoreCookieAuthOptionsTests
+{
+    private ITicketStore ticketStore = Mock.Of<ITicketStore>();
+    private IdentityServerOptions idsOptions = new();
+    private IOptions<AuthenticationOptions> authOptions = 
+        Mock.Of<IOptions<AuthenticationOptions>>();
+
+    private AuthenticationOptions authenticationOptions = new();
+
+    public PostConfigureSessionStoreCookieAuthOptionsTests()
+    {
+        Mock.Get(authOptions)
+            .Setup(x => x.Value)
+            .Returns(authenticationOptions);
+    }
+    
+    private PostConfigureSessionStoreCookieAuthOptions CreateSut() => new(ticketStore, idsOptions, authOptions);
+
+    [Fact]
+    public void PostConfigure_WhenIdentityServerOptionsCookieAuthenticationSchemeSet_AndMatchesName_ShouldConfigureTicketStore()
+    {
+        idsOptions.Authentication.CookieAuthenticationScheme = "CookieAuthenticationScheme";
+
+        var sut = CreateSut();
+
+        var fakeOpt = new CookieAuthenticationOptions();
+        sut.PostConfigure("CookieAuthenticationScheme", fakeOpt);
+
+        fakeOpt.SessionStore.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void PostConfigure_WhenIdentityServerOptionsCookieAuthenticationSchemeSet_AndDoesntMatchesName_ShouldNotConfigureTicketStore()
+    {
+        idsOptions.Authentication.CookieAuthenticationScheme = "CookieAuthenticationScheme";
+
+        var sut = CreateSut();
+
+        var fakeOpt = new CookieAuthenticationOptions();
+        sut.PostConfigure("NonMatchingValue", fakeOpt);
+
+        fakeOpt.SessionStore.Should().BeNull();
+    }
+
+    [Fact]
+    public void PostConfigure_WhenAuthenticationOptionsDefaultAuthenticateSchemeSet_AndMatchesName_ShouldConfigureTicketStore()
+    {
+        authenticationOptions.DefaultAuthenticateScheme = "DefaultAuthenticateScheme";
+
+        var sut = CreateSut();
+
+        var fakeOpt = new CookieAuthenticationOptions();
+        sut.PostConfigure("DefaultAuthenticateScheme", fakeOpt);
+
+        fakeOpt.SessionStore.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void PostConfigure_WhenAuthenticationOptionsDefaultAuthenticateSchemeSet_AndDoesntMatchesName_ShouldNotConfigureTicketStore()
+    {
+        authenticationOptions.DefaultAuthenticateScheme = "DefaultAuthenticateScheme";
+
+        var sut = CreateSut();
+
+        var fakeOpt = new CookieAuthenticationOptions();
+        sut.PostConfigure("NonMatchingValue", fakeOpt);
+
+        fakeOpt.SessionStore.Should().BeNull();
+    }
+
+    [Fact]
+    public void PostConfigure_WhenAuthenticationOptionsDefaultSchemeSet_AndMatchesName_ShouldConfigureTicketStore()
+    {
+        authenticationOptions.DefaultScheme = "DefaultScheme";
+
+        var sut = CreateSut();
+
+        var fakeOpt = new CookieAuthenticationOptions();
+        sut.PostConfigure("DefaultScheme", fakeOpt);
+
+        fakeOpt.SessionStore.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void PostConfigure_WhenAuthenticationOptionsDefaultSchemeSet_AndDoesntMatchesName_ShouldNotConfigureTicketStore()
+    {
+        authenticationOptions.DefaultScheme = "DefaultScheme";
+
+        var sut = CreateSut();
+
+        var fakeOpt = new CookieAuthenticationOptions();
+        sut.PostConfigure("NonMatchingValue", fakeOpt);
+
+        fakeOpt.SessionStore.Should().BeNull();
+    }
+}

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Extensions/ClaimExtensionsTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Extensions/ClaimExtensionsTests.cs
@@ -1,0 +1,133 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Text.Json;
+using AwesomeAssertions;
+using Open.IdentityServer.Extensions;
+using Open.IdentityServer.Stores.Serialization;
+using Xunit;
+
+namespace Open.IdentityServer.UnitTests.Extensions;
+
+public class ClaimExtensionsTests
+{
+    [Fact]
+    public void ToClaimsDictionary_WhenDuplicates_ShouldHandleAndProduceCorrectDictionary()
+    {
+        var jsonObj = new { Data = "SOMEDATA", Veriosn = 1 };
+        JsonElement jsonElement = JsonSerializer.SerializeToElement(jsonObj);
+        
+        IEnumerable<Claim> testClaims = [
+            new("Integer", "1", ClaimValueTypes.Integer, "FakeIssuer1"),
+            new("Integer", "1", ClaimValueTypes.Integer, "FakeIssuer1"),
+            new("Integer32", "150", ClaimValueTypes.Integer32, "FakeIssuer2"),
+            new("Integer32", "150", ClaimValueTypes.Integer32, "FakeIssuer2"),
+            new("Integer64", "522337203485477580", ClaimValueTypes.Integer64, "FakeIssuer3"),
+            new("Integer64", "522337203485477580", ClaimValueTypes.Integer64, "FakeIssuer3"),
+            new("Boolean", "true", ClaimValueTypes.Boolean, "FakeIssuer4"),
+            new("Boolean", "true", ClaimValueTypes.Boolean, "FakeIssuer4"),
+            new("Json", JsonSerializer.Serialize(jsonObj), IdentityServerConstants.ClaimValueTypes.Json, "FakeIssuer4"),
+            new("Json", JsonSerializer.Serialize(jsonObj), IdentityServerConstants.ClaimValueTypes.Json, "FakeIssuer4"),
+        ];
+
+        var actual = testClaims.ToClaimsDictionary();
+
+        IDictionary<string, object> expected = new Dictionary<string, object>
+        {
+            ["Integer"] = (int) 1,
+            ["Integer32"] = (int) 150,
+            ["Integer64"] = (long) 522337203485477580,
+            ["Boolean"] = (bool) true,
+            ["Json"] = (JsonElement) jsonElement,
+        };
+
+        actual.Keys.Should().HaveCount(5);
+        actual["Integer"].Should().BeEquivalentTo(expected["Integer"]);
+        actual["Integer32"].Should().BeEquivalentTo(expected["Integer32"]);
+        actual["Integer64"].Should().BeEquivalentTo(expected["Integer64"]);
+        actual["Boolean"].Should().BeEquivalentTo(expected["Boolean"]);
+        actual["Json"].ToString().Should().BeEquivalentTo(expected["Json"].ToString());
+    }
+    
+    [Fact]
+    public void ToClaimsDictionary_WhenAllClaimValueTypesProvided_ShouldAllBeConvertedToCorrectObjectInDictionary()
+    {
+        var jsonObj = new { Data = "SOMEDATA", Veriosn = 1 };
+        JsonElement jsonElement = JsonSerializer.SerializeToElement(jsonObj);
+        
+        IEnumerable<Claim> testClaims = [
+            new("Integer", "1", ClaimValueTypes.Integer, "FakeIssuer1"),
+            new("Integer32", "150", ClaimValueTypes.Integer32, "FakeIssuer2"),
+            new("Integer64", "522337203485477580", ClaimValueTypes.Integer64, "FakeIssuer3"),
+            new("Boolean", "true", ClaimValueTypes.Boolean, "FakeIssuer4"),
+            new("Json", JsonSerializer.Serialize(jsonObj), IdentityServerConstants.ClaimValueTypes.Json, "FakeIssuer4"),
+        ];
+
+        var actual = testClaims.ToClaimsDictionary();
+
+        IDictionary<string, object> expected = new Dictionary<string, object>
+        {
+            ["Integer"] = (int) 1,
+            ["Integer32"] = (int) 150,
+            ["Integer64"] = (long) 522337203485477580,
+            ["Boolean"] = (bool) true,
+            ["Json"] = (JsonElement) jsonElement,
+        };
+
+        actual["Integer"].Should().BeEquivalentTo(expected["Integer"]);
+        actual["Integer32"].Should().BeEquivalentTo(expected["Integer32"]);
+        actual["Integer64"].Should().BeEquivalentTo(expected["Integer64"]);
+        actual["Boolean"].Should().BeEquivalentTo(expected["Boolean"]);
+        actual["Json"].ToString().Should().BeEquivalentTo(expected["Json"].ToString());
+    }
+    
+    [Fact]
+    public void ToSerializableObj_WhenEnumerableOfClaimProvided_ShouldReturnArrayOfClaimLite()
+    {
+        IEnumerable<Claim> testClaims =
+        [
+            new("Type1", "Value1", ClaimValueTypes.String, "FakeIssuer1"),
+            new("Type2", "Value2", ClaimValueTypes.String, "FakeIssuer2"),
+            new("Type3", "Value3", ClaimValueTypes.String, "FakeIssuer3"),
+            new("Type4", "Value4", ClaimValueTypes.String, "FakeIssuer4"),
+        ];
+
+        var actual = testClaims.ToSerializableObj();
+        
+        ClaimLite[] expected =
+        [
+            new() { Type = "Type1", Value = "Value1", ValueType = ClaimValueTypes.String, Issuer = "FakeIssuer1" },
+            new() { Type = "Type2", Value = "Value2", ValueType = ClaimValueTypes.String, Issuer = "FakeIssuer2" },
+            new() { Type = "Type3", Value = "Value3", ValueType = ClaimValueTypes.String, Issuer = "FakeIssuer3" },
+            new() { Type = "Type4", Value = "Value4", ValueType = ClaimValueTypes.String, Issuer = "FakeIssuer4" },
+        ];
+
+        actual.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void ToClaims_WhenArrayOfClaimLiteProvided_ShouldReturnEnumerableOfClaim()
+    {
+        ClaimLite[] testClaims =
+        [
+            new() { Type = "Type1", Value = "Value1", ValueType = ClaimValueTypes.String, Issuer = "FakeIssuer1" },
+            new() { Type = "Type2", Value = "Value2", ValueType = ClaimValueTypes.String, Issuer = "FakeIssuer2" },
+            new() { Type = "Type3", Value = "Value3", ValueType = ClaimValueTypes.String, Issuer = "FakeIssuer3" },
+            new() { Type = "Type4", Value = "Value4", ValueType = ClaimValueTypes.String, Issuer = "FakeIssuer4" },
+        ];
+
+        var actual = testClaims.ToClaims();
+        
+        IEnumerable<Claim> expected =
+        [
+            new("Type1", "Value1", ClaimValueTypes.String, "FakeIssuer1"),
+            new("Type2", "Value2", ClaimValueTypes.String, "FakeIssuer2"),
+            new("Type3", "Value3", ClaimValueTypes.String, "FakeIssuer3"),
+            new("Type4", "Value4", ClaimValueTypes.String, "FakeIssuer4"),
+        ];
+
+        actual.Should().BeEquivalentTo(expected);
+    }
+}

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Extensions/ClaimsPrincipleExtensionTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Extensions/ClaimsPrincipleExtensionTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Linq;
+using System.Security.Claims;
+using AwesomeAssertions;
+using Open.IdentityServer.Extensions;
+using Open.IdentityServer.Stores.Serialization;
+using Xunit;
+
+namespace Open.IdentityServer.UnitTests.Extensions;
+
+public class ClaimsPrincipleExtensionTests
+{
+    [Fact]
+    public void ToSerializableObj_CalledOnClaimsPrincipal_Should()
+    {
+        const string authenticationType = "test-auth-type";
+        Claim[] claims =
+        [
+            new(JwtClaimTypes.Name, "alice"),
+            new(JwtClaimTypes.Role, "admin"),
+            new("custom", "value")
+        ];
+
+        ClaimsPrincipal principal = new(new ClaimsIdentity(claims, authenticationType));
+
+        ClaimsPrincipalLite actual = principal.ToSerializableObj();
+        
+        actual.AuthenticationType.Should().Be(authenticationType);
+        actual.Claims.Should().BeEquivalentTo(claims.ToSerializableObj());
+    }
+    
+    [Fact]
+    public void ToClaimsPrincipal_CalledOnClaimsPrincipalLite_Should()
+    {
+        const string authenticationType = "lite-auth-type";
+        Claim[] claims =
+        [
+            new(JwtClaimTypes.Name, "bob"),
+            new(JwtClaimTypes.Role, "reader"),
+            new("tenant", "acme")
+        ];
+
+        ClaimsPrincipalLite lite = new()
+        {
+            AuthenticationType = authenticationType,
+            Claims = claims.ToSerializableObj()
+        };
+
+        ClaimsPrincipal actual = lite.ToClaimsPrincipal();
+
+        actual.Identity.Should().NotBeNull();
+        actual.Identity!.AuthenticationType.Should().Be(authenticationType);
+
+        ClaimsIdentity identity = (ClaimsIdentity)actual.Identity;
+        identity.NameClaimType.Should().Be(JwtClaimTypes.Name);
+        identity.RoleClaimType.Should().Be(JwtClaimTypes.Role);
+
+        actual.Claims
+            .Select(c => new { c.Type, c.Value, c.ValueType, c.Issuer, c.OriginalIssuer })
+            .Should()
+            .BeEquivalentTo(
+                claims.Select(c => new { c.Type, c.Value, c.ValueType, c.Issuer, c.OriginalIssuer }),
+                options => options.WithoutStrictOrdering());
+    }
+}

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Hosting/IdentityServerMiddlewareTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Hosting/IdentityServerMiddlewareTests.cs
@@ -151,7 +151,7 @@ public class IdentityServerMiddlewareTests
         {
             await InvokeSubjectMiddleware();
         }
-        catch (Exception e)
+        catch (Exception)
         {
             // intentionally swallowed
         }
@@ -175,7 +175,7 @@ public class IdentityServerMiddlewareTests
         {
             await InvokeSubjectMiddleware();
         }
-        catch (Exception e)
+        catch (Exception)
         {
             // intentionally swallowed
         }

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/MockDataProtector.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/MockDataProtector.cs
@@ -1,0 +1,41 @@
+using System.Text;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.WebUtilities;
+using Moq;
+
+namespace Open.IdentityServer.UnitTests;
+
+public class MockDataProtector: IDataProtector
+{
+    public IDataProtector dataProtector = Mock.Of<IDataProtector>();
+    public static readonly UTF8Encoding UTF8Encoding = new(false, true);
+    public const string ProtectedPrefix = "PROTECTED--";
+
+    public MockDataProtector()
+    {
+        Mock.Get(dataProtector)
+            .Setup(x => x.Protect(It.IsAny<byte[]>()))
+            .Returns<byte[]>((plaintext) => [..UTF8Encoding.GetBytes(ProtectedPrefix), ..plaintext]);
+
+        Mock.Get(dataProtector)
+            .Setup(x => x.Unprotect(It.IsAny<byte[]>()))
+            .Returns<byte[]>((protectedData) => UTF8Encoding.GetBytes(UTF8Encoding.GetString(protectedData).Replace(ProtectedPrefix, string.Empty)));
+    }
+
+    public IDataProtector CreateProtector(string purpose) => dataProtector;
+
+    public byte[] Protect(byte[] plaintext) => dataProtector.Protect(plaintext);
+
+    public byte[] Unprotect(byte[] protectedData) => dataProtector.Unprotect(protectedData);
+
+    public void ValidateProtectedData(string protectedData, string originalString)
+    {
+        var unencodedProtectedData = UTF8Encoding.GetString(WebEncoders.Base64UrlDecode(protectedData));
+        unencodedProtectedData = unencodedProtectedData.Replace(ProtectedPrefix, string.Empty);
+        unencodedProtectedData.Should().BeEquivalentTo(originalString);
+    }
+
+    public string GenerateFakeProtectedData(string data) => 
+        WebEncoders.Base64UrlEncode(UTF8Encoding.GetBytes(ProtectedPrefix + data));
+}

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Open.IdentityServer.UnitTests.csproj
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Open.IdentityServer.UnitTests.csproj
@@ -38,4 +38,10 @@
     <ItemGroup>
         <ProjectReference Include="..\..\src\Open.IdentityServer.csproj"/>
     </ItemGroup>
+
+    <ItemGroup>
+      <Compile Include="..\..\..\EntityFramework.Storage\test\IntegrationTests\MockLogger.cs">
+        <Link>MockLogger.cs</Link>
+      </Compile>
+    </ItemGroup>
 </Project>

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Services/Default/DefaultKeyMaterialServiceTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Services/Default/DefaultKeyMaterialServiceTests.cs
@@ -7,13 +7,12 @@ using System.Threading.Tasks;
 using AwesomeAssertions;
 using Microsoft.IdentityModel.Tokens;
 using Moq;
-using Open.IdentityServer;
 using Open.IdentityServer.Models;
 using Open.IdentityServer.Services;
 using Open.IdentityServer.Stores;
 using Xunit;
 
-namespace IdentityServer.UnitTests.Services.Default;
+namespace Open.IdentityServer.UnitTests.Services.Default;
 
 public class TestSigningCredentialStore(SigningCredentials signingCredentials): ISigningCredentialStore {
     public Task<SigningCredentials> GetSigningCredentialsAsync() => Task.FromResult(signingCredentials);

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/Default/DefaultAuthorizationCodeStoreTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/Default/DefaultAuthorizationCodeStoreTests.cs
@@ -123,7 +123,6 @@ public class DefaultAuthorizationCodeStoreTests
             .Returns(_trace);
         
         const string baseHandle = "test_base_handle";
-        var expectedHandle = baseHandle + DefaultAuthorizationCodeStore.HexEncodingSuffix;
 
         Mock.Get(_handleGenerationService)
             .Setup(x => x.GenerateAsync())

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/Default/DefaultRefreshTokenStoreTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/Default/DefaultRefreshTokenStoreTests.cs
@@ -186,7 +186,6 @@ public class DefaultRefreshTokenStoreTests
             .Returns(_trace);
         
         const string baseHandle = "test_base_handle";
-        var expectedHandle = baseHandle + DefaultRefreshTokenStore.HexEncodingSuffix;
 
         Mock.Get(_handleGenerationService)
             .Setup(x => x.GenerateAsync())

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/Default/DefaultUserConsentStoreTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/Default/DefaultUserConsentStoreTests.cs
@@ -130,7 +130,6 @@ public class DefaultUserConsentStoreTests
             .Returns(_trace);
         
         const string baseHandle = "test_base_handle";
-        var expectedHandle = baseHandle + DefaultAuthorizationCodeStore.HexEncodingSuffix;
 
         Mock.Get(_handleGenerationService)
             .Setup(x => x.GenerateAsync())

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/Default/DistributedCacheAuthorizationParametersMessageStoreTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/Default/DistributedCacheAuthorizationParametersMessageStoreTests.cs
@@ -1,16 +1,16 @@
 ﻿// Copyright (c) 2026, Rock Solid Knowledge Ltd
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using AwesomeAssertions;
 using IdentityServer.UnitTests.Common;
 using Open.IdentityServer.Models;
 using Open.IdentityServer.Services;
 using Open.IdentityServer.Stores.Default;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Xunit;
 
-namespace IdentityServer.UnitTests.Stores.Default;
+namespace Open.IdentityServer.UnitTests.Stores.Default;
 
 public class DistributedCacheAuthorizationParametersMessageStoreTests
 {

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/Default/ServerSessionTicketStoreTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/Default/ServerSessionTicketStoreTests.cs
@@ -294,7 +294,7 @@ public class ServerSessionTicketStoreTests
     {
         ServerSessionTicketStore sut = CreateSut();
 
-        Func<Task> act = async () => await sut.RetrieveAsync(key);
+        Func<Task> act = async () => await sut.RetrieveAsync(key!);
 
         await act.Should().ThrowAsync<ArgumentException>();
     }

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/Default/ServerSessionTicketStoreTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/Default/ServerSessionTicketStoreTests.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Open.IdentityServer.Stores;
+using Xunit;
+
+namespace IdentityServer.UnitTests.Stores.Default;
+
+public class ServerSessionTicketStoreTests
+{
+    private readonly IDataProtectionProvider dataProtectionProvider = Mock.Of<IDataProtectionProvider>();
+    private readonly ILogger<ServerSessionTicketStore> logger;
+    
+    private ServerSessionTicketStore CreateSut() => new(dataProtectionProvider, logger);
+
+    [Fact]
+    public void _When_Should()
+    {
+        
+    }
+}

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/Default/ServerSessionTicketStoreTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/Default/ServerSessionTicketStoreTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using AwesomeAssertions;
@@ -17,6 +18,7 @@ using Open.IdentityServer;
 using Open.IdentityServer.EntityFramework.IntegrationTests;
 using Open.IdentityServer.Extensions;
 using Open.IdentityServer.Models;
+using Open.IdentityServer.Services;
 using Open.IdentityServer.Stores;
 using Open.IdentityServer.Stores.Serialization;
 using Open.IdentityServer.UnitTests;
@@ -26,10 +28,13 @@ namespace IdentityServer.UnitTests.Stores.Default;
 
 public class ServerSessionTicketStoreTests
 {
-    private readonly IIdentityServerServerSideSessionStore serverServerSideSessionStore = Mock.Of<IIdentityServerServerSideSessionStore>();
+    private readonly IIdentityServerServerSideSessionStore serverServerSideSessionStore =
+        Mock.Of<IIdentityServerServerSideSessionStore>();
+
     private readonly IDataProtectionProvider dataProtectionProvider = Mock.Of<IDataProtectionProvider>();
     private readonly MockDataProtector dataProtector = new();
     private readonly FakeTimeProvider fakeTimeProvider = new();
+    private readonly ITelemetryService telemetry = Mock.Of<ITelemetryService>();
     private readonly MockLogger<ServerSessionTicketStore> logger = new();
 
     private static readonly DateTime FakeNow = new(2026, 01, 01, 12, 0, 0, DateTimeKind.Utc);
@@ -37,13 +42,14 @@ public class ServerSessionTicketStoreTests
     public ServerSessionTicketStoreTests()
     {
         fakeTimeProvider.SetUtcNow(FakeNow);
-        
+
         Mock.Get(dataProtectionProvider)
             .Setup(x => x.CreateProtector(DataProtectionConstants.ServerSideTicketStorePurpose))
             .Returns(dataProtector);
     }
-    
-    private ServerSessionTicketStore CreateSut() => new(serverServerSideSessionStore, dataProtectionProvider, fakeTimeProvider, logger);
+
+    private ServerSessionTicketStore CreateSut() => new(serverServerSideSessionStore, dataProtectionProvider,
+        fakeTimeProvider, telemetry, logger);
 
     [Fact]
     public async Task StoreAsync_WhenOptionalValuesNotProvided_ShouldUseCorrectDefaults()
@@ -58,11 +64,11 @@ public class ServerSessionTicketStoreTests
         Mock.Get(serverServerSideSessionStore)
             .Setup(x => x.CreateSession(It.IsAny<IdentityServerServerSideSessions>()))
             .Callback<IdentityServerServerSideSessions>((session) => { createdSessionModel = session; });
-        
+
         ServerSessionTicketStore sut = CreateSut();
 
         string actualKey = await sut.StoreAsync(authenticationTicket);
-        
+
         createdSessionModel.Should().NotBeNull();
         createdSessionModel.Key.Should().NotBeNullOrWhiteSpace();
         createdSessionModel.Key.Should().Be(actualKey);
@@ -73,8 +79,9 @@ public class ServerSessionTicketStoreTests
         createdSessionModel.Created.Should().Be(FakeNow);
         createdSessionModel.Renewed.Should().Be(FakeNow);
         createdSessionModel.Expires.Should().BeNull();
-        
-        string expectedJson = JsonSerializer.Serialize(authenticationTicket.ToSerializableObj(), ServerSessionTicketStore.JsonSettings);
+
+        string expectedJson = JsonSerializer.Serialize(authenticationTicket.ToSerializableObj(),
+            ServerSessionTicketStore.JsonSettings);
         dataProtector.ValidateProtectedData(createdSessionModel.Data, expectedJson);
     }
 
@@ -87,18 +94,19 @@ public class ServerSessionTicketStoreTests
         const string displayName = "Fake User";
         DateTime issuedUtc = new(2026, 02, 19, 12, 0, 0, DateTimeKind.Utc);
         DateTime expiresUtc = new(2026, 02, 19, 12, 0, 0, DateTimeKind.Utc);
-        
-        AuthenticationTicket authenticationTicket = GenerateAuthenticationTicket(authScheme, subjectId, sessionId, displayName, issuedUtc, expiresUtc);
+
+        AuthenticationTicket authenticationTicket =
+            GenerateAuthenticationTicket(authScheme, subjectId, sessionId, displayName, issuedUtc, expiresUtc);
 
         IdentityServerServerSideSessions? createdSessionModel = null;
         Mock.Get(serverServerSideSessionStore)
             .Setup(x => x.CreateSession(It.IsAny<IdentityServerServerSideSessions>()))
             .Callback<IdentityServerServerSideSessions>((session) => { createdSessionModel = session; });
-        
+
         ServerSessionTicketStore sut = CreateSut();
 
         string actualKey = await sut.StoreAsync(authenticationTicket);
-        
+
         createdSessionModel.Should().NotBeNull();
         createdSessionModel.Key.Should().NotBeNullOrWhiteSpace();
         createdSessionModel.Key.Should().Be(actualKey);
@@ -109,8 +117,9 @@ public class ServerSessionTicketStoreTests
         createdSessionModel.Created.Should().Be(issuedUtc);
         createdSessionModel.Renewed.Should().Be(issuedUtc);
         createdSessionModel.Expires.Should().Be(expiresUtc);
-        
-        string expectedJson = JsonSerializer.Serialize(authenticationTicket.ToSerializableObj(), ServerSessionTicketStore.JsonSettings);
+
+        string expectedJson = JsonSerializer.Serialize(authenticationTicket.ToSerializableObj(),
+            ServerSessionTicketStore.JsonSettings);
         dataProtector.ValidateProtectedData(createdSessionModel.Data, expectedJson);
     }
 
@@ -122,9 +131,9 @@ public class ServerSessionTicketStoreTests
         string sessionId = Guid.NewGuid().ToString();
 
         AuthenticationTicket authenticationTicket = GenerateAuthenticationTicket(authScheme, subjectId, sessionId);
-        
+
         ServerSessionTicketStore sut = CreateSut();
-        
+
         await sut.RenewAsync("non-existent-session", authenticationTicket);
         logger.VerifyLog(LogLevel.Error, Times.Once());
     }
@@ -135,13 +144,13 @@ public class ServerSessionTicketStoreTests
         IdentityServerServerSideSessions existingSession = new IdentityServerServerSideSessions
         {
             Key = Guid.NewGuid().ToString(), Scheme = "AuthScheme", SessionId = Guid.NewGuid().ToString(),
-            SubjectId = Guid.NewGuid().ToString(), DisplayName = "John Doe", 
+            SubjectId = Guid.NewGuid().ToString(), DisplayName = "John Doe",
             Created = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc),
             Renewed = new DateTime(2026, 1, 2, 12, 0, 0, DateTimeKind.Utc),
             Expires = new DateTime(2026, 1, 31, 12, 0, 0, DateTimeKind.Utc),
             Data = "EXISTING_PROTEXTEDDAAT",
         };
-        
+
         const string authScheme = "FakeAuthScheme";
         string subjectId = Guid.NewGuid().ToString();
         string sessionId = Guid.NewGuid().ToString();
@@ -151,16 +160,16 @@ public class ServerSessionTicketStoreTests
         Mock.Get(serverServerSideSessionStore)
             .Setup(x => x.GetSession(existingSession.Key))
             .ReturnsAsync(existingSession);
-        
+
         IdentityServerServerSideSessions? createdSessionModel = null;
         Mock.Get(serverServerSideSessionStore)
             .Setup(x => x.UpdateSession(It.IsAny<IdentityServerServerSideSessions>()))
             .Callback<IdentityServerServerSideSessions>((session) => { createdSessionModel = session; });
-        
+
         ServerSessionTicketStore sut = CreateSut();
 
         await sut.RenewAsync(existingSession.Key, authenticationTicket);
-        
+
         createdSessionModel.Should().NotBeNull();
         createdSessionModel.Key.Should().NotBeNullOrWhiteSpace();
         createdSessionModel.Key.Should().Be(existingSession.Key);
@@ -171,46 +180,48 @@ public class ServerSessionTicketStoreTests
         createdSessionModel.Created.Should().Be(existingSession.Created);
         createdSessionModel.Renewed.Should().Be(FakeNow);
         createdSessionModel.Expires.Should().BeNull();
-        
-        string expectedJson = JsonSerializer.Serialize(authenticationTicket.ToSerializableObj(), ServerSessionTicketStore.JsonSettings);
+
+        string expectedJson = JsonSerializer.Serialize(authenticationTicket.ToSerializableObj(),
+            ServerSessionTicketStore.JsonSettings);
         dataProtector.ValidateProtectedData(createdSessionModel.Data, expectedJson);
     }
-    
+
     [Fact]
     public async Task RenewAsync_WhenOptionalValuesProvided_ShouldUseThem()
     {
         IdentityServerServerSideSessions existingSession = new IdentityServerServerSideSessions
         {
             Key = Guid.NewGuid().ToString(), Scheme = "AuthScheme", SessionId = Guid.NewGuid().ToString(),
-            SubjectId = Guid.NewGuid().ToString(), DisplayName = "John Doe", 
+            SubjectId = Guid.NewGuid().ToString(), DisplayName = "John Doe",
             Created = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc),
             Renewed = new DateTime(2026, 1, 2, 12, 0, 0, DateTimeKind.Utc),
             Expires = new DateTime(2026, 1, 31, 12, 0, 0, DateTimeKind.Utc),
             Data = "EXISTING_PROTEXTEDDAAT",
         };
-        
+
         const string authScheme = "FakeAuthScheme";
         string subjectId = Guid.NewGuid().ToString();
         string sessionId = Guid.NewGuid().ToString();
         const string displayName = "Fake User";
         DateTime issuedUtc = new(2026, 02, 19, 12, 0, 0, DateTimeKind.Utc);
         DateTime expiresUtc = new(2026, 02, 19, 12, 0, 0, DateTimeKind.Utc);
-        
-        AuthenticationTicket authenticationTicket = GenerateAuthenticationTicket(authScheme, subjectId, sessionId, displayName, issuedUtc, expiresUtc);
+
+        AuthenticationTicket authenticationTicket =
+            GenerateAuthenticationTicket(authScheme, subjectId, sessionId, displayName, issuedUtc, expiresUtc);
 
         Mock.Get(serverServerSideSessionStore)
             .Setup(x => x.GetSession(existingSession.Key))
             .ReturnsAsync(existingSession);
-    
+
         IdentityServerServerSideSessions? createdSessionModel = null;
         Mock.Get(serverServerSideSessionStore)
             .Setup(x => x.UpdateSession(It.IsAny<IdentityServerServerSideSessions>()))
             .Callback<IdentityServerServerSideSessions>((session) => { createdSessionModel = session; });
-        
+
         ServerSessionTicketStore sut = CreateSut();
-    
+
         await sut.RenewAsync(existingSession.Key, authenticationTicket);
-        
+
         createdSessionModel.Should().NotBeNull();
         createdSessionModel.Key.Should().NotBeNullOrWhiteSpace();
         createdSessionModel.Scheme.Should().Be(authScheme);
@@ -220,8 +231,9 @@ public class ServerSessionTicketStoreTests
         createdSessionModel.Created.Should().Be(existingSession.Created);
         createdSessionModel.Renewed.Should().Be(issuedUtc);
         createdSessionModel.Expires.Should().Be(expiresUtc);
-        
-        string expectedJson = JsonSerializer.Serialize(authenticationTicket.ToSerializableObj(), ServerSessionTicketStore.JsonSettings);
+
+        string expectedJson = JsonSerializer.Serialize(authenticationTicket.ToSerializableObj(),
+            ServerSessionTicketStore.JsonSettings);
         dataProtector.ValidateProtectedData(createdSessionModel.Data, expectedJson);
     }
 
@@ -232,49 +244,55 @@ public class ServerSessionTicketStoreTests
     public async Task RetrieveAsync_WhenArgumentNullOrEmpty_ShouldThrowArgumentException(string? key)
     {
         ServerSessionTicketStore sut = CreateSut();
-    
+
         Func<Task> act = async () => await sut.RetrieveAsync(key);
 
         await act.Should().ThrowAsync<ArgumentException>();
     }
-    
+
     [Fact]
     public async Task RetrieveAsync_WhenNoSessionStoredForKey_ShouldReturnNull()
     {
         ServerSessionTicketStore sut = CreateSut();
-    
+
         AuthenticationTicket? actual = await sut.RetrieveAsync("non-existent-session");
 
         actual.Should().BeNull();
     }
-    
+
     [Fact]
     public async Task RetrieveAsync_WhenSessionStoredForKey_ShouldReturnDeserializedAuthTicket()
     {
         IdentityServerServerSideSessions existingSession = new IdentityServerServerSideSessions
         {
             Key = Guid.NewGuid().ToString(), Scheme = "AuthScheme", SessionId = Guid.NewGuid().ToString(),
-            SubjectId = Guid.NewGuid().ToString(), DisplayName = "John Doe", 
+            SubjectId = Guid.NewGuid().ToString(), DisplayName = "John Doe",
             Created = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc),
             Renewed = new DateTime(2026, 1, 2, 12, 0, 0, DateTimeKind.Utc),
             Expires = new DateTime(2026, 1, 31, 12, 0, 0, DateTimeKind.Utc),
         };
-        SerializedAuthenticationTicket authenticationTicket = GenerateSerializedAuthenticationTicket(existingSession.Scheme, existingSession.SubjectId, existingSession.SessionId, existingSession.DisplayName, existingSession.Renewed, existingSession.Expires);
-        existingSession.Data = dataProtector.GenerateFakeProtectedData(JsonSerializer.Serialize(authenticationTicket, ServerSessionTicketStore.JsonSettings));
+        SerializedAuthenticationTicket authenticationTicket =
+            GenerateSerializedAuthenticationTicket(existingSession.Scheme, existingSession.SubjectId,
+                existingSession.SessionId, existingSession.DisplayName, existingSession.Renewed,
+                existingSession.Expires);
+        existingSession.Data =
+            dataProtector.GenerateFakeProtectedData(JsonSerializer.Serialize(authenticationTicket,
+                ServerSessionTicketStore.JsonSettings));
 
         Mock.Get(serverServerSideSessionStore)
             .Setup(x => x.GetSession(existingSession.Key))
             .ReturnsAsync(existingSession);
-        
+
         ServerSessionTicketStore sut = CreateSut();
         AuthenticationTicket? actual = await sut.RetrieveAsync(existingSession.Key);
 
         actual.Should().BeOfType<AuthenticationTicket>();
         actual.AuthenticationScheme.Should().Be(existingSession.Scheme);
-        actual.Principal.Identity?.AuthenticationType.Should().BeEquivalentTo(authenticationTicket.User.AuthenticationType);
+        actual.Principal.Identity?.AuthenticationType.Should()
+            .BeEquivalentTo(authenticationTicket.User.AuthenticationType);
         actual.Properties.Items.Should().BeEquivalentTo(authenticationTicket.Items);
     }
-    
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]
@@ -282,39 +300,84 @@ public class ServerSessionTicketStoreTests
     public async Task RemoveAsync_WhenArgumentNullOrEmpty_ShouldThrowArgumentException(string? key)
     {
         ServerSessionTicketStore sut = CreateSut();
-    
+
         Func<Task> act = async () => await sut.RemoveAsync(key!);
 
         await act.Should().ThrowAsync<ArgumentException>();
     }
-    
+
     [Fact]
     public async Task RemoveAsync_ShouldCallServerSideSessionStoreDelete()
     {
         string keyId = Guid.NewGuid().ToString();
-        
+
         ServerSessionTicketStore sut = CreateSut();
         await sut.RemoveAsync(keyId);
 
         Mock.Get(serverServerSideSessionStore)
             .Verify(x => x.DeleteSession(keyId));
     }
-    
-    private AuthenticationTicket GenerateAuthenticationTicket(string authScheme, string? subjectId, string? sessionId, string? displayName = null, DateTimeOffset? issuedUtc = null, DateTimeOffset? expiresUtc = null)
+
+    [Fact]
+    public async Task PublicMethods_WhenCalled_ShouldTelemetryTrace()
+    {
+        AuthenticationTicket authTicket =
+            GenerateAuthenticationTicket("FakeScheme", Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
+
+        List<(Func<ServerSessionTicketStore, Task> actMethod, string traceMethodName)> methods
+            =
+            [
+                (store => store.StoreAsync(authTicket), "StoreAsync"),
+                (store => store.RenewAsync("FAKE_KEY", authTicket), "RenewAsync"),
+                (store => store.RetrieveAsync("FAKE_KEY"), "RetrieveAsync"),
+                (store => store.RemoveAsync("FAKE_KEY"), "RemoveAsync")
+            ];
+
+        var sut = CreateSut();
+
+        foreach (var method in methods)
+        {
+            var trace = Mock.Of<ITrace>();
+            Mock.Get(telemetry).Setup(t => t.Trace(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<string>()))
+                .Returns(trace);
+            Mock.Get(trace).Setup(t => t.AddTag(It.IsAny<string>(), It.IsAny<string>())).Returns(trace);
+            Mock.Get(trace).Setup(t => t.AddTag(It.IsAny<string>(), It.IsAny<object>())).Returns(trace);
+
+            await method.actMethod(sut);
+
+            Mock.Get(telemetry)
+                .Verify(t => t.Trace(
+                    TelemetryConstants.TraceCategories.Stores, sut, method.traceMethodName), Times.Once);
+            Mock.Get(trace).Verify(t => t.Dispose(), Times.Once);
+        }
+
+        // Assert all methods covered
+        typeof(ServerSessionTicketStore).GetMethods()
+            .Where(m => m is { IsPublic: true, IsStatic: false, IsSpecialName: false })
+            .Where(m => m.DeclaringType == typeof(ServerSessionTicketStore))
+            .Select(m => m.Name)
+            .Distinct()
+            .Should().BeEquivalentTo(methods.Select(m => m.traceMethodName));
+    }
+
+    private AuthenticationTicket GenerateAuthenticationTicket(string authScheme, string? subjectId, string? sessionId,
+        string? displayName = null, DateTimeOffset? issuedUtc = null, DateTimeOffset? expiresUtc = null)
     {
         IdentityServerUser user = new(subjectId);
         AuthenticationProperties properties = new();
-        
+
         properties.SetSessionId(sessionId);
-        
+
         user.DisplayName = displayName;
         properties.IssuedUtc = issuedUtc;
         properties.ExpiresUtc = expiresUtc;
 
         return new AuthenticationTicket(user.CreatePrincipal(), properties, authScheme);
     }
-    
-    private SerializedAuthenticationTicket GenerateSerializedAuthenticationTicket(string authScheme, string? subjectId, string? sessionId, string? displayName = null, DateTimeOffset? issuedUtc = null, DateTimeOffset? expiresUtc = null)
+
+    private SerializedAuthenticationTicket GenerateSerializedAuthenticationTicket(string authScheme, string? subjectId,
+        string? sessionId, string? displayName = null, DateTimeOffset? issuedUtc = null,
+        DateTimeOffset? expiresUtc = null)
     {
         List<ClaimLite> claims = [];
 
@@ -334,17 +397,17 @@ public class ServerSessionTicketStoreTests
         {
             items["session_id"] = sessionId;
         }
-        
+
         if (issuedUtc != null)
         {
             items[".issued"] = issuedUtc.Value.ToString("R");
         }
-        
+
         if (expiresUtc != null)
         {
             items[".expires"] = expiresUtc.Value.ToString("R");
         }
-        
+
         return new SerializedAuthenticationTicket
         {
             Scheme = authScheme,

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/Default/ServerSessionTicketStoreTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/Default/ServerSessionTicketStoreTests.cs
@@ -359,8 +359,13 @@ public class ServerSessionTicketStoreTests
 
         actual.Should().BeOfType<AuthenticationTicket>();
         actual.AuthenticationScheme.Should().Be(existingSession.Scheme);
+        actual.Principal.Identity.Should().NotBeNull();
         actual.Principal.Identity?.AuthenticationType.Should()
             .BeEquivalentTo(authenticationTicket.User.AuthenticationType);
+        actual.Principal.Identity?.Name.Should().BeEquivalentTo(existingSession.DisplayName);
+        actual.Principal.Identities.Should().Contain(x => 
+            x.NameClaimType == JwtClaimTypes.Name && 
+            x.RoleClaimType == JwtClaimTypes.Role);
         actual.Properties.Items.Should().BeEquivalentTo(authenticationTicket.Items);
     }
 

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/Default/ServerSessionTicketStoreTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/Default/ServerSessionTicketStoreTests.cs
@@ -11,20 +11,17 @@ using System.Threading.Tasks;
 using AwesomeAssertions;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.DataProtection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
-using Open.IdentityServer;
 using Open.IdentityServer.EntityFramework.IntegrationTests;
 using Open.IdentityServer.Extensions;
 using Open.IdentityServer.Models;
 using Open.IdentityServer.Services;
 using Open.IdentityServer.Stores;
 using Open.IdentityServer.Stores.Serialization;
-using Open.IdentityServer.UnitTests;
 using Xunit;
 
-namespace IdentityServer.UnitTests.Stores.Default;
+namespace Open.IdentityServer.UnitTests.Stores.Default;
 
 public class ServerSessionTicketStoreTests
 {
@@ -124,21 +121,6 @@ public class ServerSessionTicketStoreTests
     }
 
     [Fact]
-    public async Task RenewAsync_WhenNoSessionWithKey_ShouldLogError()
-    {
-        const string authScheme = "FakeAuthScheme";
-        string subjectId = Guid.NewGuid().ToString();
-        string sessionId = Guid.NewGuid().ToString();
-
-        AuthenticationTicket authenticationTicket = GenerateAuthenticationTicket(authScheme, subjectId, sessionId);
-
-        ServerSessionTicketStore sut = CreateSut();
-
-        await sut.RenewAsync("non-existent-session", authenticationTicket);
-        logger.VerifyLog(LogLevel.Error, Times.Once());
-    }
-
-    [Fact]
     public async Task RenewAsync_WhenOptionalValuesNotProvided_ShouldUseCorrectDefaults()
     {
         IdentityServerServerSideSessions existingSession = new IdentityServerServerSideSessions
@@ -213,24 +195,60 @@ public class ServerSessionTicketStoreTests
             .Setup(x => x.GetSession(existingSession.Key))
             .ReturnsAsync(existingSession);
 
-        IdentityServerServerSideSessions? createdSessionModel = null;
+        IdentityServerServerSideSessions? updatedSessionModel = null;
         Mock.Get(serverServerSideSessionStore)
             .Setup(x => x.UpdateSession(It.IsAny<IdentityServerServerSideSessions>()))
-            .Callback<IdentityServerServerSideSessions>((session) => { createdSessionModel = session; });
+            .Callback<IdentityServerServerSideSessions>((session) => { updatedSessionModel = session; });
 
         ServerSessionTicketStore sut = CreateSut();
 
         await sut.RenewAsync(existingSession.Key, authenticationTicket);
 
+        updatedSessionModel.Should().NotBeNull();
+        updatedSessionModel.Key.Should().NotBeNullOrWhiteSpace();
+        updatedSessionModel.Key.Should().Be(existingSession.Key);
+        updatedSessionModel.Scheme.Should().Be(authScheme);
+        updatedSessionModel.SessionId.Should().Be(sessionId);
+        updatedSessionModel.SubjectId.Should().Be(subjectId);
+        updatedSessionModel.DisplayName.Should().Be(displayName);
+        updatedSessionModel.Created.Should().Be(existingSession.Created);
+        updatedSessionModel.Renewed.Should().Be(issuedUtc);
+        updatedSessionModel.Expires.Should().Be(expiresUtc);
+
+        string expectedJson = JsonSerializer.Serialize(authenticationTicket.ToSerializableObj(),
+            ServerSessionTicketStore.JsonSettings);
+        dataProtector.ValidateProtectedData(updatedSessionModel.Data, expectedJson);
+    }
+    
+    [Fact]
+    public async Task RenewAsync_WhenNoExistingSessionWithKey_ShouldCreateNewSession()
+    {
+        const string authScheme = "FakeAuthScheme";
+        string subjectId = Guid.NewGuid().ToString();
+        string sessionId = Guid.NewGuid().ToString();
+
+        AuthenticationTicket authenticationTicket = GenerateAuthenticationTicket(authScheme, subjectId, sessionId);
+
+        IdentityServerServerSideSessions? createdSessionModel = null;
+        Mock.Get(serverServerSideSessionStore)
+            .Setup(x => x.CreateSession(It.IsAny<IdentityServerServerSideSessions>()))
+            .Callback<IdentityServerServerSideSessions>((session) => { createdSessionModel = session; });
+
+        ServerSessionTicketStore sut = CreateSut();
+        
+        const string nonExistent = "NonExistentSession";
+        await sut.RenewAsync(nonExistent, authenticationTicket);
+
         createdSessionModel.Should().NotBeNull();
         createdSessionModel.Key.Should().NotBeNullOrWhiteSpace();
+        createdSessionModel.Key.Should().Be(nonExistent);
         createdSessionModel.Scheme.Should().Be(authScheme);
         createdSessionModel.SessionId.Should().Be(sessionId);
         createdSessionModel.SubjectId.Should().Be(subjectId);
-        createdSessionModel.DisplayName.Should().Be(displayName);
-        createdSessionModel.Created.Should().Be(existingSession.Created);
-        createdSessionModel.Renewed.Should().Be(issuedUtc);
-        createdSessionModel.Expires.Should().Be(expiresUtc);
+        createdSessionModel.DisplayName.Should().BeNull();
+        createdSessionModel.Created.Should().Be(FakeNow);
+        createdSessionModel.Renewed.Should().Be(FakeNow);
+        createdSessionModel.Expires.Should().BeNull();
 
         string expectedJson = JsonSerializer.Serialize(authenticationTicket.ToSerializableObj(),
             ServerSessionTicketStore.JsonSettings);

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/Default/ServerSessionTicketStoreTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/Default/ServerSessionTicketStoreTests.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
+using Open.IdentityServer.DataProtection;
 using Open.IdentityServer.EntityFramework.IntegrationTests;
 using Open.IdentityServer.Extensions;
 using Open.IdentityServer.Models;
@@ -77,9 +78,15 @@ public class ServerSessionTicketStoreTests
         createdSessionModel.Renewed.Should().Be(FakeNow);
         createdSessionModel.Expires.Should().BeNull();
 
+        var jsonElement = JsonElement.Parse(createdSessionModel.Data);
+
+        jsonElement.GetProperty("Version").GetInt32().Should().Be(1);
+        var actualPayload = jsonElement.GetProperty("Payload").GetString();
+        actualPayload.Should().NotBeNull();
+
         string expectedJson = JsonSerializer.Serialize(authenticationTicket.ToSerializableObj(),
             ServerSessionTicketStore.JsonSettings);
-        dataProtector.ValidateProtectedData(createdSessionModel.Data, expectedJson);
+        dataProtector.ValidateProtectedData(actualPayload, expectedJson);
     }
 
     [Fact]
@@ -115,9 +122,15 @@ public class ServerSessionTicketStoreTests
         createdSessionModel.Renewed.Should().Be(issuedUtc);
         createdSessionModel.Expires.Should().Be(expiresUtc);
 
+        var jsonElement = JsonElement.Parse(createdSessionModel.Data);
+
+        jsonElement.GetProperty("Version").GetInt32().Should().Be(1);
+        var actualPayload = jsonElement.GetProperty("Payload").GetString();
+        actualPayload.Should().NotBeNull();
+        
         string expectedJson = JsonSerializer.Serialize(authenticationTicket.ToSerializableObj(),
             ServerSessionTicketStore.JsonSettings);
-        dataProtector.ValidateProtectedData(createdSessionModel.Data, expectedJson);
+        dataProtector.ValidateProtectedData(actualPayload, expectedJson);
     }
 
     [Fact]
@@ -163,9 +176,15 @@ public class ServerSessionTicketStoreTests
         createdSessionModel.Renewed.Should().Be(FakeNow);
         createdSessionModel.Expires.Should().BeNull();
 
+        var jsonElement = JsonElement.Parse(createdSessionModel.Data);
+
+        jsonElement.GetProperty("Version").GetInt32().Should().Be(1);
+        var actualPayload = jsonElement.GetProperty("Payload").GetString();
+        actualPayload.Should().NotBeNull();
+
         string expectedJson = JsonSerializer.Serialize(authenticationTicket.ToSerializableObj(),
             ServerSessionTicketStore.JsonSettings);
-        dataProtector.ValidateProtectedData(createdSessionModel.Data, expectedJson);
+        dataProtector.ValidateProtectedData(actualPayload, expectedJson);
     }
 
     [Fact]
@@ -215,9 +234,15 @@ public class ServerSessionTicketStoreTests
         updatedSessionModel.Renewed.Should().Be(issuedUtc);
         updatedSessionModel.Expires.Should().Be(expiresUtc);
 
+        var jsonElement = JsonElement.Parse(updatedSessionModel.Data);
+
+        jsonElement.GetProperty("Version").GetInt32().Should().Be(1);
+        var actualPayload = jsonElement.GetProperty("Payload").GetString();
+        actualPayload.Should().NotBeNull();
+
         string expectedJson = JsonSerializer.Serialize(authenticationTicket.ToSerializableObj(),
             ServerSessionTicketStore.JsonSettings);
-        dataProtector.ValidateProtectedData(updatedSessionModel.Data, expectedJson);
+        dataProtector.ValidateProtectedData(actualPayload, expectedJson);
     }
     
     [Fact]
@@ -250,9 +275,15 @@ public class ServerSessionTicketStoreTests
         createdSessionModel.Renewed.Should().Be(FakeNow);
         createdSessionModel.Expires.Should().BeNull();
 
+        var jsonElement = JsonElement.Parse(createdSessionModel.Data);
+
+        jsonElement.GetProperty("Version").GetInt32().Should().Be(1);
+        var actualPayload = jsonElement.GetProperty("Payload").GetString();
+        actualPayload.Should().NotBeNull();
+
         string expectedJson = JsonSerializer.Serialize(authenticationTicket.ToSerializableObj(),
             ServerSessionTicketStore.JsonSettings);
-        dataProtector.ValidateProtectedData(createdSessionModel.Data, expectedJson);
+        dataProtector.ValidateProtectedData(actualPayload, expectedJson);
     }
 
     [Theory]
@@ -278,6 +309,31 @@ public class ServerSessionTicketStoreTests
         actual.Should().BeNull();
     }
 
+    [Theory]
+    [InlineData("{invalid.json}")]
+    [InlineData("{\"Version\": 2, Payload: \"SOMEDATA\"}")]
+    public async Task RetrieveAsync_WhenSessionDataDeserialisationFails_ShouldReturnNull(string data)
+    {
+        IdentityServerServerSideSessions existingSession = new IdentityServerServerSideSessions
+        {
+            Key = Guid.NewGuid().ToString(), Scheme = "AuthScheme", SessionId = Guid.NewGuid().ToString(),
+            SubjectId = Guid.NewGuid().ToString(), DisplayName = "John Doe",
+            Created = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc),
+            Renewed = new DateTime(2026, 1, 2, 12, 0, 0, DateTimeKind.Utc),
+            Expires = new DateTime(2026, 1, 31, 12, 0, 0, DateTimeKind.Utc),
+            Data = data
+        };
+
+        Mock.Get(serverServerSideSessionStore)
+            .Setup(x => x.GetSession(existingSession.Key))
+            .ReturnsAsync(existingSession);
+
+        ServerSessionTicketStore sut = CreateSut();
+        AuthenticationTicket? actual = await sut.RetrieveAsync(existingSession.Key);
+
+        actual.Should().BeNull();
+    }
+
     [Fact]
     public async Task RetrieveAsync_WhenSessionStoredForKey_ShouldReturnDeserializedAuthTicket()
     {
@@ -289,13 +345,10 @@ public class ServerSessionTicketStoreTests
             Renewed = new DateTime(2026, 1, 2, 12, 0, 0, DateTimeKind.Utc),
             Expires = new DateTime(2026, 1, 31, 12, 0, 0, DateTimeKind.Utc),
         };
-        SerializedAuthenticationTicket authenticationTicket =
-            GenerateSerializedAuthenticationTicket(existingSession.Scheme, existingSession.SubjectId,
-                existingSession.SessionId, existingSession.DisplayName, existingSession.Renewed,
-                existingSession.Expires);
-        existingSession.Data =
-            dataProtector.GenerateFakeProtectedData(JsonSerializer.Serialize(authenticationTicket,
-                ServerSessionTicketStore.JsonSettings));
+        SerializedAuthenticationTicket authenticationTicket = GenerateSerializedAuthenticationTicket(
+            existingSession.Scheme, existingSession.SubjectId, existingSession.SessionId, 
+            existingSession.DisplayName, existingSession.Renewed, existingSession.Expires);
+        existingSession.Data = GenerateFakeData(authenticationTicket);
 
         Mock.Get(serverServerSideSessionStore)
             .Setup(x => x.GetSession(existingSession.Key))
@@ -393,6 +446,17 @@ public class ServerSessionTicketStoreTests
         return new AuthenticationTicket(user.CreatePrincipal(), properties, authScheme);
     }
 
+    private string GenerateFakeData(SerializedAuthenticationTicket serializedAuthenticationTicket)
+    {
+        DataProtectedSessionData sessionData = new DataProtectedSessionData
+        {
+            Payload = dataProtector.GenerateFakeProtectedData(JsonSerializer.Serialize(serializedAuthenticationTicket,
+                    ServerSessionTicketStore.JsonSettings))
+        };
+
+        return JsonSerializer.Serialize(sessionData, ServerSessionTicketStore.JsonSettings);
+    }
+    
     private SerializedAuthenticationTicket GenerateSerializedAuthenticationTicket(string authScheme, string? subjectId,
         string? sessionId, string? displayName = null, DateTimeOffset? issuedUtc = null,
         DateTimeOffset? expiresUtc = null)

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/Default/ServerSessionTicketStoreTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/Default/ServerSessionTicketStoreTests.cs
@@ -1,21 +1,359 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
+using Open.IdentityServer;
+using Open.IdentityServer.EntityFramework.IntegrationTests;
+using Open.IdentityServer.Extensions;
+using Open.IdentityServer.Models;
 using Open.IdentityServer.Stores;
+using Open.IdentityServer.Stores.Serialization;
+using Open.IdentityServer.UnitTests;
 using Xunit;
 
 namespace IdentityServer.UnitTests.Stores.Default;
 
 public class ServerSessionTicketStoreTests
 {
+    private readonly IIdentityServerServerSideSessionStore serverServerSideSessionStore = Mock.Of<IIdentityServerServerSideSessionStore>();
     private readonly IDataProtectionProvider dataProtectionProvider = Mock.Of<IDataProtectionProvider>();
-    private readonly ILogger<ServerSessionTicketStore> logger;
+    private readonly MockDataProtector dataProtector = new();
+    private readonly FakeTimeProvider fakeTimeProvider = new();
+    private readonly MockLogger<ServerSessionTicketStore> logger = new();
+
+    private static readonly DateTime FakeNow = new(2026, 01, 01, 12, 0, 0, DateTimeKind.Utc);
+
+    public ServerSessionTicketStoreTests()
+    {
+        fakeTimeProvider.SetUtcNow(FakeNow);
+        
+        Mock.Get(dataProtectionProvider)
+            .Setup(x => x.CreateProtector(DataProtectionConstants.ServerSideTicketStorePurpose))
+            .Returns(dataProtector);
+    }
     
-    private ServerSessionTicketStore CreateSut() => new(dataProtectionProvider, logger);
+    private ServerSessionTicketStore CreateSut() => new(serverServerSideSessionStore, dataProtectionProvider, fakeTimeProvider, logger);
 
     [Fact]
-    public void _When_Should()
+    public async Task StoreAsync_WhenOptionalValuesNotProvided_ShouldUseCorrectDefaults()
     {
+        const string authScheme = "FakeAuthScheme";
+        string subjectId = Guid.NewGuid().ToString();
+        string sessionId = Guid.NewGuid().ToString();
+
+        AuthenticationTicket authenticationTicket = GenerateAuthenticationTicket(authScheme, subjectId, sessionId);
+
+        IdentityServerServerSideSessions? createdSessionModel = null;
+        Mock.Get(serverServerSideSessionStore)
+            .Setup(x => x.CreateSession(It.IsAny<IdentityServerServerSideSessions>()))
+            .Callback<IdentityServerServerSideSessions>((session) => { createdSessionModel = session; });
         
+        ServerSessionTicketStore sut = CreateSut();
+
+        string actualKey = await sut.StoreAsync(authenticationTicket);
+        
+        createdSessionModel.Should().NotBeNull();
+        createdSessionModel.Key.Should().NotBeNullOrWhiteSpace();
+        createdSessionModel.Key.Should().Be(actualKey);
+        createdSessionModel.Scheme.Should().Be(authScheme);
+        createdSessionModel.SessionId.Should().Be(sessionId);
+        createdSessionModel.SubjectId.Should().Be(subjectId);
+        createdSessionModel.DisplayName.Should().BeNull();
+        createdSessionModel.Created.Should().Be(FakeNow);
+        createdSessionModel.Renewed.Should().Be(FakeNow);
+        createdSessionModel.Expires.Should().BeNull();
+        
+        string expectedJson = JsonSerializer.Serialize(authenticationTicket.ToSerializableObj(), ServerSessionTicketStore.JsonSettings);
+        dataProtector.ValidateProtectedData(createdSessionModel.Data, expectedJson);
+    }
+
+    [Fact]
+    public async Task StoreAsync_WhenOptionalValuesProvided_ShouldUseThem()
+    {
+        const string authScheme = "FakeAuthScheme";
+        string subjectId = Guid.NewGuid().ToString();
+        string sessionId = Guid.NewGuid().ToString();
+        const string displayName = "Fake User";
+        DateTime issuedUtc = new(2026, 02, 19, 12, 0, 0, DateTimeKind.Utc);
+        DateTime expiresUtc = new(2026, 02, 19, 12, 0, 0, DateTimeKind.Utc);
+        
+        AuthenticationTicket authenticationTicket = GenerateAuthenticationTicket(authScheme, subjectId, sessionId, displayName, issuedUtc, expiresUtc);
+
+        IdentityServerServerSideSessions? createdSessionModel = null;
+        Mock.Get(serverServerSideSessionStore)
+            .Setup(x => x.CreateSession(It.IsAny<IdentityServerServerSideSessions>()))
+            .Callback<IdentityServerServerSideSessions>((session) => { createdSessionModel = session; });
+        
+        ServerSessionTicketStore sut = CreateSut();
+
+        string actualKey = await sut.StoreAsync(authenticationTicket);
+        
+        createdSessionModel.Should().NotBeNull();
+        createdSessionModel.Key.Should().NotBeNullOrWhiteSpace();
+        createdSessionModel.Key.Should().Be(actualKey);
+        createdSessionModel.Scheme.Should().Be(authScheme);
+        createdSessionModel.SessionId.Should().Be(sessionId);
+        createdSessionModel.SubjectId.Should().Be(subjectId);
+        createdSessionModel.DisplayName.Should().Be(displayName);
+        createdSessionModel.Created.Should().Be(issuedUtc);
+        createdSessionModel.Renewed.Should().Be(issuedUtc);
+        createdSessionModel.Expires.Should().Be(expiresUtc);
+        
+        string expectedJson = JsonSerializer.Serialize(authenticationTicket.ToSerializableObj(), ServerSessionTicketStore.JsonSettings);
+        dataProtector.ValidateProtectedData(createdSessionModel.Data, expectedJson);
+    }
+
+    [Fact]
+    public async Task RenewAsync_WhenNoSessionWithKey_ShouldLogError()
+    {
+        const string authScheme = "FakeAuthScheme";
+        string subjectId = Guid.NewGuid().ToString();
+        string sessionId = Guid.NewGuid().ToString();
+
+        AuthenticationTicket authenticationTicket = GenerateAuthenticationTicket(authScheme, subjectId, sessionId);
+        
+        ServerSessionTicketStore sut = CreateSut();
+        
+        await sut.RenewAsync("non-existent-session", authenticationTicket);
+        logger.VerifyLog(LogLevel.Error, Times.Once());
+    }
+
+    [Fact]
+    public async Task RenewAsync_WhenOptionalValuesNotProvided_ShouldUseCorrectDefaults()
+    {
+        IdentityServerServerSideSessions existingSession = new IdentityServerServerSideSessions
+        {
+            Key = Guid.NewGuid().ToString(), Scheme = "AuthScheme", SessionId = Guid.NewGuid().ToString(),
+            SubjectId = Guid.NewGuid().ToString(), DisplayName = "John Doe", 
+            Created = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc),
+            Renewed = new DateTime(2026, 1, 2, 12, 0, 0, DateTimeKind.Utc),
+            Expires = new DateTime(2026, 1, 31, 12, 0, 0, DateTimeKind.Utc),
+            Data = "EXISTING_PROTEXTEDDAAT",
+        };
+        
+        const string authScheme = "FakeAuthScheme";
+        string subjectId = Guid.NewGuid().ToString();
+        string sessionId = Guid.NewGuid().ToString();
+
+        AuthenticationTicket authenticationTicket = GenerateAuthenticationTicket(authScheme, subjectId, sessionId);
+
+        Mock.Get(serverServerSideSessionStore)
+            .Setup(x => x.GetSession(existingSession.Key))
+            .ReturnsAsync(existingSession);
+        
+        IdentityServerServerSideSessions? createdSessionModel = null;
+        Mock.Get(serverServerSideSessionStore)
+            .Setup(x => x.UpdateSession(It.IsAny<IdentityServerServerSideSessions>()))
+            .Callback<IdentityServerServerSideSessions>((session) => { createdSessionModel = session; });
+        
+        ServerSessionTicketStore sut = CreateSut();
+
+        await sut.RenewAsync(existingSession.Key, authenticationTicket);
+        
+        createdSessionModel.Should().NotBeNull();
+        createdSessionModel.Key.Should().NotBeNullOrWhiteSpace();
+        createdSessionModel.Key.Should().Be(existingSession.Key);
+        createdSessionModel.Scheme.Should().Be(authScheme);
+        createdSessionModel.SessionId.Should().Be(sessionId);
+        createdSessionModel.SubjectId.Should().Be(subjectId);
+        createdSessionModel.DisplayName.Should().BeNull();
+        createdSessionModel.Created.Should().Be(existingSession.Created);
+        createdSessionModel.Renewed.Should().Be(FakeNow);
+        createdSessionModel.Expires.Should().BeNull();
+        
+        string expectedJson = JsonSerializer.Serialize(authenticationTicket.ToSerializableObj(), ServerSessionTicketStore.JsonSettings);
+        dataProtector.ValidateProtectedData(createdSessionModel.Data, expectedJson);
+    }
+    
+    [Fact]
+    public async Task RenewAsync_WhenOptionalValuesProvided_ShouldUseThem()
+    {
+        IdentityServerServerSideSessions existingSession = new IdentityServerServerSideSessions
+        {
+            Key = Guid.NewGuid().ToString(), Scheme = "AuthScheme", SessionId = Guid.NewGuid().ToString(),
+            SubjectId = Guid.NewGuid().ToString(), DisplayName = "John Doe", 
+            Created = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc),
+            Renewed = new DateTime(2026, 1, 2, 12, 0, 0, DateTimeKind.Utc),
+            Expires = new DateTime(2026, 1, 31, 12, 0, 0, DateTimeKind.Utc),
+            Data = "EXISTING_PROTEXTEDDAAT",
+        };
+        
+        const string authScheme = "FakeAuthScheme";
+        string subjectId = Guid.NewGuid().ToString();
+        string sessionId = Guid.NewGuid().ToString();
+        const string displayName = "Fake User";
+        DateTime issuedUtc = new(2026, 02, 19, 12, 0, 0, DateTimeKind.Utc);
+        DateTime expiresUtc = new(2026, 02, 19, 12, 0, 0, DateTimeKind.Utc);
+        
+        AuthenticationTicket authenticationTicket = GenerateAuthenticationTicket(authScheme, subjectId, sessionId, displayName, issuedUtc, expiresUtc);
+
+        Mock.Get(serverServerSideSessionStore)
+            .Setup(x => x.GetSession(existingSession.Key))
+            .ReturnsAsync(existingSession);
+    
+        IdentityServerServerSideSessions? createdSessionModel = null;
+        Mock.Get(serverServerSideSessionStore)
+            .Setup(x => x.UpdateSession(It.IsAny<IdentityServerServerSideSessions>()))
+            .Callback<IdentityServerServerSideSessions>((session) => { createdSessionModel = session; });
+        
+        ServerSessionTicketStore sut = CreateSut();
+    
+        await sut.RenewAsync(existingSession.Key, authenticationTicket);
+        
+        createdSessionModel.Should().NotBeNull();
+        createdSessionModel.Key.Should().NotBeNullOrWhiteSpace();
+        createdSessionModel.Scheme.Should().Be(authScheme);
+        createdSessionModel.SessionId.Should().Be(sessionId);
+        createdSessionModel.SubjectId.Should().Be(subjectId);
+        createdSessionModel.DisplayName.Should().Be(displayName);
+        createdSessionModel.Created.Should().Be(existingSession.Created);
+        createdSessionModel.Renewed.Should().Be(issuedUtc);
+        createdSessionModel.Expires.Should().Be(expiresUtc);
+        
+        string expectedJson = JsonSerializer.Serialize(authenticationTicket.ToSerializableObj(), ServerSessionTicketStore.JsonSettings);
+        dataProtector.ValidateProtectedData(createdSessionModel.Data, expectedJson);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task RetrieveAsync_WhenArgumentNullOrEmpty_ShouldThrowArgumentException(string? key)
+    {
+        ServerSessionTicketStore sut = CreateSut();
+    
+        Func<Task> act = async () => await sut.RetrieveAsync(key);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+    
+    [Fact]
+    public async Task RetrieveAsync_WhenNoSessionStoredForKey_ShouldReturnNull()
+    {
+        ServerSessionTicketStore sut = CreateSut();
+    
+        AuthenticationTicket? actual = await sut.RetrieveAsync("non-existent-session");
+
+        actual.Should().BeNull();
+    }
+    
+    [Fact]
+    public async Task RetrieveAsync_WhenSessionStoredForKey_ShouldReturnDeserializedAuthTicket()
+    {
+        IdentityServerServerSideSessions existingSession = new IdentityServerServerSideSessions
+        {
+            Key = Guid.NewGuid().ToString(), Scheme = "AuthScheme", SessionId = Guid.NewGuid().ToString(),
+            SubjectId = Guid.NewGuid().ToString(), DisplayName = "John Doe", 
+            Created = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc),
+            Renewed = new DateTime(2026, 1, 2, 12, 0, 0, DateTimeKind.Utc),
+            Expires = new DateTime(2026, 1, 31, 12, 0, 0, DateTimeKind.Utc),
+        };
+        SerializedAuthenticationTicket authenticationTicket = GenerateSerializedAuthenticationTicket(existingSession.Scheme, existingSession.SubjectId, existingSession.SessionId, existingSession.DisplayName, existingSession.Renewed, existingSession.Expires);
+        existingSession.Data = dataProtector.GenerateFakeProtectedData(JsonSerializer.Serialize(authenticationTicket, ServerSessionTicketStore.JsonSettings));
+
+        Mock.Get(serverServerSideSessionStore)
+            .Setup(x => x.GetSession(existingSession.Key))
+            .ReturnsAsync(existingSession);
+        
+        ServerSessionTicketStore sut = CreateSut();
+        AuthenticationTicket? actual = await sut.RetrieveAsync(existingSession.Key);
+
+        actual.Should().BeOfType<AuthenticationTicket>();
+        actual.AuthenticationScheme.Should().Be(existingSession.Scheme);
+        actual.Principal.Identity?.AuthenticationType.Should().BeEquivalentTo(authenticationTicket.User.AuthenticationType);
+        actual.Properties.Items.Should().BeEquivalentTo(authenticationTicket.Items);
+    }
+    
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task RemoveAsync_WhenArgumentNullOrEmpty_ShouldThrowArgumentException(string? key)
+    {
+        ServerSessionTicketStore sut = CreateSut();
+    
+        Func<Task> act = async () => await sut.RemoveAsync(key!);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+    
+    [Fact]
+    public async Task RemoveAsync_ShouldCallServerSideSessionStoreDelete()
+    {
+        string keyId = Guid.NewGuid().ToString();
+        
+        ServerSessionTicketStore sut = CreateSut();
+        await sut.RemoveAsync(keyId);
+
+        Mock.Get(serverServerSideSessionStore)
+            .Verify(x => x.DeleteSession(keyId));
+    }
+    
+    private AuthenticationTicket GenerateAuthenticationTicket(string authScheme, string? subjectId, string? sessionId, string? displayName = null, DateTimeOffset? issuedUtc = null, DateTimeOffset? expiresUtc = null)
+    {
+        IdentityServerUser user = new(subjectId);
+        AuthenticationProperties properties = new();
+        
+        properties.SetSessionId(sessionId);
+        
+        user.DisplayName = displayName;
+        properties.IssuedUtc = issuedUtc;
+        properties.ExpiresUtc = expiresUtc;
+
+        return new AuthenticationTicket(user.CreatePrincipal(), properties, authScheme);
+    }
+    
+    private SerializedAuthenticationTicket GenerateSerializedAuthenticationTicket(string authScheme, string? subjectId, string? sessionId, string? displayName = null, DateTimeOffset? issuedUtc = null, DateTimeOffset? expiresUtc = null)
+    {
+        List<ClaimLite> claims = [];
+
+        if (subjectId != null)
+        {
+            claims.Add(new ClaimLite { Type = "sub", Value = subjectId, ValueType = "", Issuer = "", });
+        }
+
+        if (displayName != null)
+        {
+            claims.Add(new ClaimLite { Type = "name", Value = displayName, ValueType = "", Issuer = "", });
+        }
+
+        var items = new Dictionary<string, string>();
+
+        if (sessionId != null)
+        {
+            items["session_id"] = sessionId;
+        }
+        
+        if (issuedUtc != null)
+        {
+            items[".issued"] = issuedUtc.Value.ToString("R");
+        }
+        
+        if (expiresUtc != null)
+        {
+            items[".expires"] = expiresUtc.Value.ToString("R");
+        }
+        
+        return new SerializedAuthenticationTicket
+        {
+            Scheme = authScheme,
+            User = new ClaimsPrincipalLite
+            {
+                AuthenticationType = "Open.IdentityServer",
+                Claims = claims.ToArray(),
+            },
+            Items = items,
+        };
     }
 }

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/InMemorySessionStoreTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/InMemorySessionStoreTests.cs
@@ -1,0 +1,206 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Open.IdentityServer.Models;
+using Open.IdentityServer.Stores;
+using Xunit;
+
+namespace Open.IdentityServer.UnitTests.Stores;
+
+public class InMemorySessionStoreTests
+{
+    private InMemorySessionStore CreateSut(IDictionary<string, IdentityServerServerSideSessions>? seedDictionary = null) => new(seedDictionary);
+    
+    [Fact]
+    public async Task GetSession_WhenSessionWithKeyIsntStored_ShouldReturnNull()
+    {
+        InMemorySessionStore sut = CreateSut();
+
+        IdentityServerServerSideSessions? actual = await sut.GetSession("non-session-key");
+
+        actual.Should().BeNull();
+    }
+    
+    [Fact]
+    public async Task GetSession_WhenSessionWithKeyStored_ShouldReturnSession()
+    {
+        Dictionary<string, IdentityServerServerSideSessions> seededSessions = new Dictionary<string, IdentityServerServerSideSessions>
+        {
+            ["session-0"] = new() { Key = "session-0", DisplayName = "Session 0", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
+            ["session-1"] = new() { Key = "session-1", DisplayName = "Session 1", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
+            ["session-2"] = new() { Key = "session-2", DisplayName = "Session 2", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
+            ["session-3"] = new() { Key = "session-3", DisplayName = "Session 3", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
+        };
+        
+        InMemorySessionStore sut = CreateSut(seededSessions);
+
+        const string testKey = "session-2";
+        IdentityServerServerSideSessions? actual = await sut.GetSession(testKey);
+
+        actual.Should().BeEquivalentTo(seededSessions[testKey]);
+    }
+    
+    [Fact]
+    public async Task CreateSession_WhenSessionWithKeyExists_ShouldStoreSession()
+    {
+        IdentityServerServerSideSessions existingSession = new()
+        {
+            Key = "session-0", DisplayName = "Session 0", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString()
+        };
+        
+        IdentityServerServerSideSessions newSession = new()
+        {
+            Key = existingSession.Key, DisplayName = "Session 0 Updated", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString()
+        };
+
+        InMemorySessionStore sut = CreateSut(new Dictionary<string, IdentityServerServerSideSessions>
+        {
+            [existingSession.Key] = existingSession,
+        });
+        IdentityServerServerSideSessions? preTestMethodsCall = await sut.GetSession(newSession.Key);
+        preTestMethodsCall.Should().BeEquivalentTo(existingSession);
+        
+        await sut.CreateSession(newSession);
+        IdentityServerServerSideSessions? actual = await sut.GetSession(newSession.Key);
+        actual.Should().BeEquivalentTo(newSession);
+    }
+    
+    [Fact]
+    public async Task CreateSession_WhenSessionWithKeyExists_ShouldNotThrow()
+    {
+        IdentityServerServerSideSessions existingSession = new()
+        {
+            Key = "session-0", DisplayName = "Session 0", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString()
+        };
+        
+        IdentityServerServerSideSessions newSession = new()
+        {
+            Key = existingSession.Key, DisplayName = "Session 0 Updated", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString()
+        };
+
+        InMemorySessionStore sut = CreateSut(new Dictionary<string, IdentityServerServerSideSessions>
+        {
+            [existingSession.Key] = existingSession,
+        });
+        
+        Func<Task> act = async () => await sut.CreateSession(newSession);
+        await act.Should().NotThrowAsync();
+    }
+    
+    [Fact]
+    public async Task CreateSession_WhenDoesntExist_ShouldStoreSession()
+    {
+        const string testKey = "session-0";
+        IdentityServerServerSideSessions sessionToCreate = new()
+        {
+            Key = testKey, DisplayName = "Session 0", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString()
+        };
+
+        InMemorySessionStore sut = CreateSut();
+        IdentityServerServerSideSessions? preTestMethodsCall = await sut.GetSession(testKey);
+        preTestMethodsCall.Should().BeNull();
+        
+        await sut.CreateSession(sessionToCreate);
+        IdentityServerServerSideSessions? actual = await sut.GetSession(testKey);
+        actual.Should().BeEquivalentTo(sessionToCreate);
+    }
+    
+    [Fact]
+    public async Task UpdateSession_WhenSessionDoesntExistsWithKey_ShouldStoreSession()
+    {
+        const string testKey = "session-0";
+        IdentityServerServerSideSessions newSession = new()
+        {
+            Key = testKey, DisplayName = "Session 0 Updated", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString()
+        };
+
+        InMemorySessionStore sut = CreateSut();
+        
+        await sut.UpdateSession(newSession);
+        IdentityServerServerSideSessions? actual = await sut.GetSession(testKey);
+        actual.Should().BeEquivalentTo(newSession);
+    }
+    
+    [Fact]
+    public async Task UpdateSession_WhenSessionDoesntExistsWithKey_ShouldNotThrow()
+    {
+        const string testKey = "session-0";
+        IdentityServerServerSideSessions newSession = new()
+        {
+            Key = testKey, DisplayName = "Session 0 Updated", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString()
+        };
+
+        InMemorySessionStore sut = CreateSut();
+        
+        Func<Task> act = async () => await sut.UpdateSession(newSession);
+        await act.Should().NotThrowAsync();
+    }
+    
+    [Fact]
+    public async Task UpdateSession_WhenSessionExistsWithKey_ShouldReplaceStoredSession()
+    {
+        const string testKey = "session-0";
+        IdentityServerServerSideSessions existingSession = new()
+        {
+            Key = testKey, DisplayName = "Session 0", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString()
+        };
+        
+        IdentityServerServerSideSessions newSession = new()
+        {
+            Key = testKey, DisplayName = "Session 0 Updated", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString()
+        };
+
+        InMemorySessionStore sut = CreateSut(new Dictionary<string, IdentityServerServerSideSessions>
+        {
+            [testKey] = existingSession,
+        });
+        IdentityServerServerSideSessions? preTestMethodsCall = await sut.GetSession(testKey);
+        preTestMethodsCall.Should().BeEquivalentTo(existingSession);
+        
+        await sut.UpdateSession(newSession);
+        IdentityServerServerSideSessions? actual = await sut.GetSession(testKey);
+        actual.Should().BeEquivalentTo(newSession);
+    }
+    
+    [Fact]
+    public async Task DeleteSession_WhenSessionDoesntExists_ShouldNotThrow()
+    {
+        Dictionary<string, IdentityServerServerSideSessions> seededSessions = new Dictionary<string, IdentityServerServerSideSessions>
+        {
+            ["session-0"] = new() { Key = "session-0", DisplayName = "Session 0", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
+            ["session-1"] = new() { Key = "session-1", DisplayName = "Session 1", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
+            ["session-2"] = new() { Key = "session-2", DisplayName = "Session 2", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
+            ["session-3"] = new() { Key = "session-3", DisplayName = "Session 3", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
+        };
+        InMemorySessionStore sut = CreateSut(seededSessions);
+        
+        Func<Task> act = async () => await sut.DeleteSession("non-exitsnt-session");
+
+        await act.Should().NotThrowAsync();
+    }
+    
+    [Fact]
+    public async Task DeleteSession_WhenSessionExists_ShouldBeRemoved()
+    {
+        const string testKey = "session-2";
+        Dictionary<string, IdentityServerServerSideSessions> seededSessions = new Dictionary<string, IdentityServerServerSideSessions>
+        {
+            ["session-0"] = new() { Key = "session-0", DisplayName = "Session 0", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
+            ["session-1"] = new() { Key = "session-1", DisplayName = "Session 1", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
+            ["session-2"] = new() { Key = "session-2", DisplayName = "Session 2", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
+            ["session-3"] = new() { Key = "session-3", DisplayName = "Session 3", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
+        };
+        
+        InMemorySessionStore sut = CreateSut(seededSessions);
+        IdentityServerServerSideSessions? preTestMethodsCall = await sut.GetSession(testKey);
+        preTestMethodsCall.Should().BeEquivalentTo(seededSessions[testKey]);
+        
+        await sut.DeleteSession(testKey);
+
+        IdentityServerServerSideSessions? actual = await sut.GetSession(testKey);
+        actual.Should().BeNull();
+    }
+}

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/InMemorySessionStoreTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/InMemorySessionStoreTests.cs
@@ -15,10 +15,17 @@ namespace Open.IdentityServer.UnitTests.Stores;
 
 public class InMemorySessionStoreTests
 {
-    private InMemorySessionStore CreateSut(IDictionary<string, IdentityServerServerSideSessions>? seedDictionary = null) => 
-        seedDictionary == null ? 
-            new InMemorySessionStore() : 
-            new InMemorySessionStore(seedDictionary);
+    private InMemorySessionStore CreateSut(IEnumerable<IdentityServerServerSideSessions>? seedSessions = null)
+    {
+        InMemorySessionStore sut = new InMemorySessionStore();
+
+        foreach (var seedSession in seedSessions ?? [])
+        {
+            sut.CreateSession(seedSession);
+        }
+
+        return sut;
+    }
     
     [Fact]
     public async Task GetSession_WhenSessionWithKeyIsntStored_ShouldReturnNull()
@@ -33,20 +40,20 @@ public class InMemorySessionStoreTests
     [Fact]
     public async Task GetSession_WhenSessionWithKeyStored_ShouldReturnSession()
     {
-        Dictionary<string, IdentityServerServerSideSessions> seededSessions = new Dictionary<string, IdentityServerServerSideSessions>
-        {
-            ["session-0"] = new() { Key = "session-0", DisplayName = "Session 0", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
-            ["session-1"] = new() { Key = "session-1", DisplayName = "Session 1", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
-            ["session-2"] = new() { Key = "session-2", DisplayName = "Session 2", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
-            ["session-3"] = new() { Key = "session-3", DisplayName = "Session 3", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
-        };
+        const string testKey = "session-2";
+        IdentityServerServerSideSessions testSession = new() { Key = testKey, DisplayName = "Session 2", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() };
+        IEnumerable<IdentityServerServerSideSessions> seededSessions = [
+            new() { Key = "session-0", DisplayName = "Session 0", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
+            new() { Key = "session-1", DisplayName = "Session 1", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
+            testSession,
+            new() { Key = "session-3", DisplayName = "Session 3", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
+        ];
         
         InMemorySessionStore sut = CreateSut(seededSessions);
 
-        const string testKey = "session-2";
         IdentityServerServerSideSessions? actual = await sut.GetSession(testKey);
 
-        actual.Should().BeEquivalentTo(seededSessions[testKey]);
+        actual.Should().BeEquivalentTo(testSession);
     }
     
     [Fact]
@@ -62,10 +69,7 @@ public class InMemorySessionStoreTests
             Key = existingSession.Key, DisplayName = "Session 0 Updated", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString()
         };
 
-        InMemorySessionStore sut = CreateSut(new Dictionary<string, IdentityServerServerSideSessions>
-        {
-            [existingSession.Key] = existingSession,
-        });
+        InMemorySessionStore sut = CreateSut([existingSession]);
         IdentityServerServerSideSessions? preTestMethodsCall = await sut.GetSession(newSession.Key);
         preTestMethodsCall.Should().BeEquivalentTo(existingSession);
         
@@ -87,10 +91,7 @@ public class InMemorySessionStoreTests
             Key = existingSession.Key, DisplayName = "Session 0 Updated", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString()
         };
 
-        InMemorySessionStore sut = CreateSut(new Dictionary<string, IdentityServerServerSideSessions>
-        {
-            [existingSession.Key] = existingSession,
-        });
+        InMemorySessionStore sut = CreateSut([existingSession]);
         
         Func<Task> act = async () => await sut.CreateSession(newSession);
         await act.Should().NotThrowAsync();
@@ -159,10 +160,7 @@ public class InMemorySessionStoreTests
             Key = testKey, DisplayName = "Session 0 Updated", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString()
         };
 
-        InMemorySessionStore sut = CreateSut(new Dictionary<string, IdentityServerServerSideSessions>
-        {
-            [testKey] = existingSession,
-        });
+        InMemorySessionStore sut = CreateSut([existingSession]);
         IdentityServerServerSideSessions? preTestMethodsCall = await sut.GetSession(testKey);
         preTestMethodsCall.Should().BeEquivalentTo(existingSession);
         
@@ -174,13 +172,12 @@ public class InMemorySessionStoreTests
     [Fact]
     public async Task DeleteSession_WhenSessionDoesntExists_ShouldNotThrow()
     {
-        Dictionary<string, IdentityServerServerSideSessions> seededSessions = new Dictionary<string, IdentityServerServerSideSessions>
-        {
-            ["session-0"] = new() { Key = "session-0", DisplayName = "Session 0", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
-            ["session-1"] = new() { Key = "session-1", DisplayName = "Session 1", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
-            ["session-2"] = new() { Key = "session-2", DisplayName = "Session 2", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
-            ["session-3"] = new() { Key = "session-3", DisplayName = "Session 3", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
-        };
+        IEnumerable<IdentityServerServerSideSessions> seededSessions = [
+            new() { Key = "session-0", DisplayName = "Session 0", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
+            new() { Key = "session-1", DisplayName = "Session 1", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
+            new() { Key = "session-2", DisplayName = "Session 2", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
+            new() { Key = "session-3", DisplayName = "Session 3", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
+        ];
         InMemorySessionStore sut = CreateSut(seededSessions);
         
         Func<Task> act = async () => await sut.DeleteSession("non-exitsnt-session");
@@ -192,17 +189,17 @@ public class InMemorySessionStoreTests
     public async Task DeleteSession_WhenSessionExists_ShouldBeRemoved()
     {
         const string testKey = "session-2";
-        Dictionary<string, IdentityServerServerSideSessions> seededSessions = new Dictionary<string, IdentityServerServerSideSessions>
-        {
-            ["session-0"] = new() { Key = "session-0", DisplayName = "Session 0", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
-            ["session-1"] = new() { Key = "session-1", DisplayName = "Session 1", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
-            ["session-2"] = new() { Key = "session-2", DisplayName = "Session 2", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
-            ["session-3"] = new() { Key = "session-3", DisplayName = "Session 3", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
-        };
+        IdentityServerServerSideSessions testSession = new() { Key = testKey, DisplayName = "Session 2", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() };
+        IEnumerable<IdentityServerServerSideSessions> seededSessions = [
+            new() { Key = "session-0", DisplayName = "Session 0", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
+            new() { Key = "session-1", DisplayName = "Session 1", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
+            testSession,
+            new() { Key = "session-3", DisplayName = "Session 3", SessionId = Guid.NewGuid().ToString(), SubjectId = Guid.NewGuid().ToString() },
+        ];
         
         InMemorySessionStore sut = CreateSut(seededSessions);
         IdentityServerServerSideSessions? preTestMethodsCall = await sut.GetSession(testKey);
-        preTestMethodsCall.Should().BeEquivalentTo(seededSessions[testKey]);
+        preTestMethodsCall.Should().BeEquivalentTo(testSession);
         
         await sut.DeleteSession(testKey);
 

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/InMemorySessionStoreTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/InMemorySessionStoreTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
 #nullable enable
 
 using System;
@@ -12,7 +15,10 @@ namespace Open.IdentityServer.UnitTests.Stores;
 
 public class InMemorySessionStoreTests
 {
-    private InMemorySessionStore CreateSut(IDictionary<string, IdentityServerServerSideSessions>? seedDictionary = null) => new(seedDictionary);
+    private InMemorySessionStore CreateSut(IDictionary<string, IdentityServerServerSideSessions>? seedDictionary = null) => 
+        seedDictionary == null ? 
+            new InMemorySessionStore() : 
+            new InMemorySessionStore(seedDictionary);
     
     [Fact]
     public async Task GetSession_WhenSessionWithKeyIsntStored_ShouldReturnNull()

--- a/src/Storage/src/Models/Compatibility/IdentityServerServerSideSessions.cs
+++ b/src/Storage/src/Models/Compatibility/IdentityServerServerSideSessions.cs
@@ -1,3 +1,8 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+#nullable enable
+
 using System;
 
 namespace Open.IdentityServer.Models;

--- a/src/Storage/src/Models/Compatibility/IdentityServerServerSideSessions.cs
+++ b/src/Storage/src/Models/Compatibility/IdentityServerServerSideSessions.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace Open.IdentityServer.Models;
+
+/// <summary>
+/// A model for Server Side Sessions stored in a IdentityServer database
+/// </summary>
+public class IdentityServerServerSideSessions
+{
+    /// <summary>
+    /// Get or set key
+    /// </summary>
+    public string Key { get; set; } = null!;
+    
+    /// <summary>
+    /// Get or set scheme
+    /// </summary>
+    public string Scheme { get; set; } = null!;
+    
+    /// <summary>
+    /// Get or set subject identifier
+    /// </summary>
+    public string SubjectId { get; set; } = null!;
+    
+    /// <summary>
+    /// Get or set session identifier
+    /// </summary>
+    public string? SessionId { get; set; }
+    
+    /// <summary>
+    /// Get or set display name
+    /// </summary>
+    public string? DisplayName { get; set; }
+    
+    /// <summary>
+    /// Get or set created datetime
+    /// </summary>
+    public DateTime Created { get; set; }
+    
+    /// <summary>
+    /// Get or set renewed datetime
+    /// </summary>
+    public DateTime Renewed { get; set; }
+    
+    /// <summary>
+    /// Get or set expires datetime
+    /// </summary>
+    public DateTime? Expires { get; set; }
+    
+    /// <summary>
+    /// Get or set data value
+    /// </summary>
+    public string Data { get; set; } = null!;
+}

--- a/src/Storage/src/Stores/Compatibility/IIdentityServerServerSideSessionStore.cs
+++ b/src/Storage/src/Stores/Compatibility/IIdentityServerServerSideSessionStore.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+#nullable enable
+
+using System.Threading.Tasks;
+using Open.IdentityServer.Models;
+
+namespace Open.IdentityServer.Stores;
+
+/// <summary>
+/// Storage and retrieval of server server side sessions
+/// </summary>
+public interface IIdentityServerServerSideSessionStore
+{
+    /// <summary>
+    /// Gets server side session using unique key
+    /// </summary>
+    /// <param name="key">unique key of session</param>
+    /// <returns>found session or null if not found</returns>
+    public Task<IdentityServerServerSideSessions?> GetSession(string key);
+    
+    /// <summary>
+    /// Stores the provides session model, must have a unique key set
+    /// </summary>
+    /// <param name="session">session model to store</param>
+    /// <returns>void</returns>
+    public Task CreateSession(IdentityServerServerSideSessions session);
+    
+    /// <summary>
+    /// Updates the provided server side session model, model with unique key must already exist in store
+    /// </summary>
+    /// <param name="session">session model to update</param>
+    /// <returns>void</returns>
+    public Task UpdateSession(IdentityServerServerSideSessions session);
+    
+    /// <summary>
+    /// Deletes server side session using unique key
+    /// </summary>
+    /// <param name="key">unique key of session</param>
+    /// <returns>void</returns>
+    public Task DeleteSession(string key);
+}

--- a/src/Storage/src/Stores/Compatibility/IIdentityServerServerSideSessionStore.cs
+++ b/src/Storage/src/Stores/Compatibility/IIdentityServerServerSideSessionStore.cs
@@ -9,19 +9,19 @@ using Open.IdentityServer.Models;
 namespace Open.IdentityServer.Stores;
 
 /// <summary>
-/// Storage and retrieval of server server side sessions
+/// Storage and retrieval of server-side sessions
 /// </summary>
 public interface IIdentityServerServerSideSessionStore
 {
     /// <summary>
-    /// Gets server side session using unique key
+    /// Gets server-side session using unique key
     /// </summary>
     /// <param name="key">unique key of session</param>
     /// <returns>found session or null if not found</returns>
     public Task<IdentityServerServerSideSessions?> GetSession(string key);
     
     /// <summary>
-    /// Stores the provides session model, must have a unique key set
+    /// Stores the provided session model, must have a unique key set
     /// </summary>
     /// <param name="session">session model to store</param>
     /// <returns>void</returns>
@@ -35,7 +35,7 @@ public interface IIdentityServerServerSideSessionStore
     public Task UpdateSession(IdentityServerServerSideSessions session);
     
     /// <summary>
-    /// Deletes server side session using unique key
+    /// Deletes server-side session using unique key
     /// </summary>
     /// <param name="key">unique key of session</param>
     /// <returns>void</returns>

--- a/src/Storage/src/Stores/Serialization/ClaimLite.cs
+++ b/src/Storage/src/Stores/Serialization/ClaimLite.cs
@@ -16,4 +16,6 @@ public class ClaimLite
     public string Value { get; set; }
     /// <summary>Gets or sets the claim value type.</summary>
     public string ValueType { get; set; }
+    /// <summary>Gets or sets the claim issuer.</summary>
+    public string Issuer { get; set; }
 }

--- a/src/Storage/src/Stores/Serialization/SerializedAuthenticationTicket.cs
+++ b/src/Storage/src/Stores/Serialization/SerializedAuthenticationTicket.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace Open.IdentityServer.Stores.Serialization;
+
+/// <summary>
+/// Model for serialized authentication ticket
+/// </summary>
+public class SerializedAuthenticationTicket
+{
+    /// <summary>
+    /// The authentication scheme
+    /// </summary>
+    public string Scheme { get; init; } = null!;
+
+    /// <summary>
+    /// The authenticated user
+    /// </summary>
+    public ClaimsPrincipalLite User { get; init; } = null!;
+
+    /// <summary>
+    /// The property items
+    /// </summary>
+    public IDictionary<string, string> Items { get; init; } = null!;
+}

--- a/src/Storage/src/TelemetryConstants.cs
+++ b/src/Storage/src/TelemetryConstants.cs
@@ -52,6 +52,7 @@ public static class TelemetryConstants
         public const string Resource = "resource";
         public const string Subject = "subject";
         public const string Session = "session";
+        public const string Key = "key";
     }
     
     public static class TraceCategories


### PR DESCRIPTION
## Description

Implemented initial storage of session in database following the existing db schema created for compatibility.

- Addition of an implementation of ITicketStore to tie into asp.net session storage
- Implementation of an EF core storage class for IIdentityServerServerSideSessionStore interface.
- Extension method for configuring server side sessions

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

_Describe how the change has been tested.  New code should be covered by appropriate unit and/or integration tests._

## LLM Usage

Used for guidance on setting up integration tests, and understanding more about how the sessions work in the existing IdentityServer4 codebase.

## Other context
n/a