### PR TITLE
Recatoring to improve nullable and readability of DataProtectedIdentityServerKeyMaterialConverter 

### DIFF
--- a/src/Open.IdentityServer/src/Configuration/CryptoHelper.cs
+++ b/src/Open.IdentityServer/src/Configuration/CryptoHelper.cs
@@ -123,7 +123,7 @@ public static class CryptoHelper
     /// <param name="algorithm">The algorithm to get the curve name for.</param>
     /// <returns>The name of the curve corresponding to the algorithm.</returns>
     /// <exception cref="NotSupportedException"></exception>
-    public static string? GetCurveNameForAlgorithm(this string algorithm)
+    public static string GetCurveNameForAlgorithm(this string algorithm)
     {
         return algorithm switch
         {

--- a/src/Open.IdentityServer/src/Configuration/CryptoHelper.cs
+++ b/src/Open.IdentityServer/src/Configuration/CryptoHelper.cs
@@ -129,7 +129,7 @@ public static class CryptoHelper
         {
             "ES256" => "P-256",
             "ES384" => "P-384",
-            "ES512" => "P-521",
+            "ES521" => "P-521",
             _ => throw new ArgumentOutOfRangeException(nameof(algorithm), "Unexpected algorithm value for EC Curve")
         };
     }

--- a/src/Open.IdentityServer/src/Configuration/CryptoHelper.cs
+++ b/src/Open.IdentityServer/src/Configuration/CryptoHelper.cs
@@ -122,7 +122,7 @@ public static class CryptoHelper
     /// </summary>
     /// <param name="algorithm">The algorithm to get the curve name for.</param>
     /// <returns>The name of the curve corresponding to the algorithm.</returns>
-    /// <exception cref="NotSupportedException"></exception>
+    /// <exception cref="NotSupportedException">The supplied <paramref name="algorithm"/> is not supported.</exception>
     public static string GetCurveNameForAlgorithm(this string algorithm)
     {
         return algorithm switch
@@ -130,7 +130,7 @@ public static class CryptoHelper
             "ES256" => "P-256",
             "ES384" => "P-384",
             "ES521" => "P-521",
-            _ => throw new ArgumentOutOfRangeException(nameof(algorithm), "Unexpected algorithm value for EC Curve")
+            _ => throw new NotSupportedException($"Unexpected algorithm value for EC Curve: {algorithm}")
         };
     }
 

--- a/src/Open.IdentityServer/src/Configuration/CryptoHelper.cs
+++ b/src/Open.IdentityServer/src/Configuration/CryptoHelper.cs
@@ -98,6 +98,43 @@ public static class CryptoHelper
     }
 
     /// <summary>
+    /// Returns <see langword="true"/> if the algorithm is an RSA algorithm (RSxxx or PSxxx)
+    /// </summary>
+    /// <param name="algorithm">The algorithm to check.</param>
+    /// <returns><see langword="true"/> if the algorithm is an RSA algorithm; otherwise, <see langword="false"/>.</returns>
+    public static bool IsRsaAlgorithm(this string algorithm)
+    {
+        return algorithm.StartsWith('R') || algorithm.StartsWith('P');
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the algorithm is an EC algorithm (Exxx)
+    /// </summary>
+    /// <param name="algorithm">The algorithm to check.</param>
+    /// <returns><see langword="true"/> if the algorithm is an EC algorithm; otherwise, <see langword="false"/>.</returns>
+    public static bool IsEcAlgorithm(this string algorithm)
+    {
+        return algorithm.StartsWith('E');
+    }
+
+    /// <summary>
+    /// Returns the matching named curve for a given algorithm
+    /// </summary>
+    /// <param name="algorithm">The algorithm to get the curve name for.</param>
+    /// <returns>The name of the curve corresponding to the algorithm.</returns>
+    /// <exception cref="NotSupportedException"></exception>
+    public static string? GetCurveNameForAlgorithm(this string algorithm)
+    {
+        return algorithm switch
+        {
+            "ES256" => "P-256",
+            "ES384" => "P-384",
+            "ES512" => "P-521",
+            _ => throw new ArgumentOutOfRangeException(nameof(algorithm), "Unexpected algorithm value for EC Curve")
+        };
+    }
+
+    /// <summary>
     /// Returns the matching named curve for RFC 7518 crv value
     /// </summary>
     internal static ECCurve GetCurveFromCrvValue(string crv)

--- a/src/Open.IdentityServer/src/DataProtection/DataProtectedIdentityServerKeyMaterialConverter.cs
+++ b/src/Open.IdentityServer/src/DataProtection/DataProtectedIdentityServerKeyMaterialConverter.cs
@@ -45,8 +45,7 @@ public class DataProtectedIdentityServerKeyMaterialConverter(IDataProtectionProv
             dataProtector.Unprotect(keyMaterial.Data) : 
             keyMaterial.Data;
 
-        if (!keyMaterial.IsX509Certificate &&
-            (keyMaterial.Algorithm.StartsWith('R') || keyMaterial.Algorithm.StartsWith('P')))
+        if (!keyMaterial.IsX509Certificate && keyMaterial.Algorithm.IsRsaAlgorithm())
         {
             var keyData = JsonSerializer.Deserialize<RsaIdentityServerKeyData>(unprotectedData, Settings);
 
@@ -54,18 +53,12 @@ public class DataProtectedIdentityServerKeyMaterialConverter(IDataProtectionProv
             signingKey.Credentials = new SigningCredentials(new RsaSecurityKey(keyData.Parameters) { KeyId = keyData.Id }, keyData.Algorithm);
         }
         
-        if (!keyMaterial.IsX509Certificate && keyMaterial.Algorithm.StartsWith('E'))
+        if (!keyMaterial.IsX509Certificate && keyMaterial.Algorithm.IsEcAlgorithm())
         {
             var keyData = JsonSerializer.Deserialize<EcIdentityServerKeyData>(unprotectedData, Settings);
 
-            ECCurve curve = keyMaterial.Algorithm switch
-            {
-                "ES256" => CryptoHelper.GetCurveFromCrvValue("P-256"),
-                "ES384" => CryptoHelper.GetCurveFromCrvValue("P-384"),
-                "ES521" => CryptoHelper.GetCurveFromCrvValue("P-521"),
-                _ => throw new ArgumentOutOfRangeException(nameof(keyMaterial.Algorithm), "Unexpected algorithm value for EC Curve")
-            };
-
+            ECCurve curve = CryptoHelper.GetCurveFromCrvValue(
+                keyMaterial.Algorithm.GetCurveNameForAlgorithm());
             var ecdsa = ECDsa.Create(new ECParameters { Curve = curve, D = keyData.D, Q = keyData.Q });
             
             signingKey.Created = keyData.Created;

--- a/src/Open.IdentityServer/src/Extensions/StringsExtensions.cs
+++ b/src/Open.IdentityServer/src/Extensions/StringsExtensions.cs
@@ -7,9 +7,12 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Text.Encodings.Web;
+
+#nullable enable
 
 namespace Open.IdentityServer.Extensions;
 
@@ -47,7 +50,7 @@ internal static class StringExtensions
         return input.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).ToList();
     }
 
-    public static List<string> ParseScopesString(this string scopes)
+    public static List<string>? ParseScopesString(this string? scopes)
     {
         if (scopes.IsMissing())
         {
@@ -67,13 +70,13 @@ internal static class StringExtensions
     }
 
     [DebuggerStepThrough]
-    public static bool IsMissing(this string value)
+    public static bool IsMissing([NotNullWhen(false)] this string? value)
     {
         return string.IsNullOrWhiteSpace(value);
     }
 
     [DebuggerStepThrough]
-    public static bool IsMissingOrTooLong(this string value, int maxLength)
+    public static bool IsMissingOrTooLong(this string? value, int maxLength)
     {
         if (string.IsNullOrWhiteSpace(value))
         {
@@ -89,13 +92,13 @@ internal static class StringExtensions
     }
 
     [DebuggerStepThrough]
-    public static bool IsPresent(this string value)
+    public static bool IsPresent([NotNullWhen(true)] this string? value)
     {
         return !string.IsNullOrWhiteSpace(value);
     }
 
     [DebuggerStepThrough]
-    public static string EnsureLeadingSlash(this string url)
+    public static string? EnsureLeadingSlash(this string? url)
     {
         if (url != null && !url.StartsWith("/"))
         {
@@ -106,7 +109,7 @@ internal static class StringExtensions
     }
 
     [DebuggerStepThrough]
-    public static string EnsureTrailingSlash(this string url)
+    public static string? EnsureTrailingSlash(this string? url)
     {
         if (url != null && !url.EndsWith("/"))
         {
@@ -117,7 +120,7 @@ internal static class StringExtensions
     }
 
     [DebuggerStepThrough]
-    public static string RemoveLeadingSlash(this string url)
+    public static string? RemoveLeadingSlash(this string? url)
     {
         if (url != null && url.StartsWith("/"))
         {
@@ -128,7 +131,7 @@ internal static class StringExtensions
     }
 
     [DebuggerStepThrough]
-    public static string RemoveTrailingSlash(this string url)
+    public static string? RemoveTrailingSlash(this string? url)
     {
         if (url != null && url.EndsWith("/"))
         {
@@ -139,9 +142,9 @@ internal static class StringExtensions
     }
 
     [DebuggerStepThrough]
-    public static string CleanUrlPath(this string url)
+    public static string CleanUrlPath(this string? url)
     {
-        if (String.IsNullOrWhiteSpace(url)) url = "/";
+        if (string.IsNullOrWhiteSpace(url)) url = "/";
 
         if (url != "/" && url.EndsWith("/"))
         {
@@ -153,7 +156,7 @@ internal static class StringExtensions
 
     [DebuggerStepThrough]
     // Clone of UrlHelperBase.CheckIsLocalUrl from https://github.com/dotnet/aspnetcore/blob/3f1acb59718cadf111a0a796681e3d3509bb3381/src/Mvc/Mvc.Core/src/Routing/UrlHelperBase.cs
-    public static bool IsLocalUrl(this string url)
+    public static bool IsLocalUrl(this string? url)
     {
         if (string.IsNullOrEmpty(url))
         {
@@ -246,7 +249,7 @@ internal static class StringExtensions
     }
 
     [DebuggerStepThrough]
-    public static NameValueCollection ReadQueryStringAsNameValueCollection(this string url)
+    public static NameValueCollection ReadQueryStringAsNameValueCollection(this string? url)
     {
         if (url != null)
         {
@@ -266,7 +269,7 @@ internal static class StringExtensions
         return new NameValueCollection();
     }
 
-    public static string GetOrigin(this string url)
+    public static string? GetOrigin(this string? url)
     {
         if (url != null)
         {

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Utility/InternalStringExtensions.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Utility/InternalStringExtensions.cs
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Modified by Rock Solid Knowledge Ltd. Copyright in modifications 2026, Rock Solid Knowledge Ltd.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 #nullable enable
 
@@ -11,13 +12,13 @@ namespace IdentityServer.IntegrationTests.Utility;
 internal static class InternalStringExtensions
 {
     [DebuggerStepThrough]
-    public static bool IsMissing(this string value)
+    public static bool IsMissing([NotNullWhen(false)] this string? value)
     {
         return string.IsNullOrWhiteSpace(value);
     }
 
     [DebuggerStepThrough]
-    public static bool IsPresent(this string value)
+    public static bool IsPresent([NotNullWhen(true)] this string? value)
     {
         return !(value.IsMissing());
     }

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Configuration/CryptoHelperTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Configuration/CryptoHelperTests.cs
@@ -33,7 +33,7 @@ public class CryptoHelperTests
     [Theory]
     [InlineData("ES256")]
     [InlineData("ES384")]
-    [InlineData("ES512")]
+    [InlineData("ES521")]
     public void IsEcAlgorithm_ShouldReturnTrueForEcAlgorithms(string algorithm)
     {
         algorithm.IsEcAlgorithm().Should().BeTrue();
@@ -56,7 +56,7 @@ public class CryptoHelperTests
     [Theory]
     [InlineData("ES256", "P-256")]
     [InlineData("ES384", "P-384")]
-    [InlineData("ES512", "P-521")]
+    [InlineData("ES521", "P-521")]
     public void GetCurveNameForAlgorithm_ShouldReturnCorrectCurveNameForEcAlgorithms(string algorithm, string expectedCurveName)
     {
         algorithm.GetCurveNameForAlgorithm().Should().Be(expectedCurveName);

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Configuration/CryptoHelperTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Configuration/CryptoHelperTests.cs
@@ -71,9 +71,9 @@ public class CryptoHelperTests
     [InlineData("PS512")]
     [InlineData("HS256")]
     [InlineData("AES256")]
-    public void GetCurveNameForAlgorithm_ShouldThrowArgumentOutOfRangeExceptionForNonEcAlgorithms(string algorithm)
+    public void GetCurveNameForAlgorithm_ShouldThrowNotSupportedExceptionForNonEcAlgorithms(string algorithm)
     {
         Action act = () => algorithm.GetCurveNameForAlgorithm();
-        act.Should().Throw<ArgumentOutOfRangeException>();
+        act.Should().Throw<NotSupportedException>();
     }
 }

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Configuration/CryptoHelperTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Configuration/CryptoHelperTests.cs
@@ -1,0 +1,79 @@
+﻿using AwesomeAssertions;
+using Open.IdentityServer.Configuration;
+using System;
+using Xunit;
+
+namespace Open.IdentityServer.UnitTests.Configuration;
+
+public class CryptoHelperTests
+{
+    [Theory]
+    [InlineData("RS256")]
+    [InlineData("RS384")]
+    [InlineData("RS512")]
+    [InlineData("PS256")]
+    [InlineData("PS384")]
+    [InlineData("PS512")]
+    public void IsRsaAlgorithm_ShouldReturnTrueForRsaAlgorithms(string algorithm)
+    {
+        algorithm.IsRsaAlgorithm().Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("ES256")]
+    [InlineData("ES384")]
+    [InlineData("ES512")]
+    [InlineData("HS256")]
+    [InlineData("AES256")]
+    public void IsRsaAlgorithm_ShouldReturnFalseForNonRsaAlgorithms(string algorithm)
+    {
+        algorithm.IsRsaAlgorithm().Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("ES256")]
+    [InlineData("ES384")]
+    [InlineData("ES512")]
+    public void IsEcAlgorithm_ShouldReturnTrueForEcAlgorithms(string algorithm)
+    {
+        algorithm.IsEcAlgorithm().Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("RS256")]
+    [InlineData("RS384")]
+    [InlineData("RS512")]
+    [InlineData("PS256")]
+    [InlineData("PS384")]
+    [InlineData("PS512")]
+    [InlineData("HS256")]
+    [InlineData("AES256")]
+    public void IsEcAlgorithm_ShouldReturnFalseForNonEcAlgorithms(string algorithm)
+    {
+        algorithm.IsEcAlgorithm().Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("ES256", "P-256")]
+    [InlineData("ES384", "P-384")]
+    [InlineData("ES512", "P-521")]
+    public void GetCurveNameForAlgorithm_ShouldReturnCorrectCurveNameForEcAlgorithms(string algorithm, string expectedCurveName)
+    {
+        algorithm.GetCurveNameForAlgorithm().Should().Be(expectedCurveName);
+    }
+
+    [Theory]
+    [InlineData("RS256")]
+    [InlineData("RS384")]
+    [InlineData("RS512")]
+    [InlineData("PS256")]
+    [InlineData("PS384")]
+    [InlineData("PS512")]
+    [InlineData("HS256")]
+    [InlineData("AES256")]
+    public void GetCurveNameForAlgorithm_ShouldThrowArgumentOutOfRangeExceptionForNonEcAlgorithms(string algorithm)
+    {
+        Action act = () => algorithm.GetCurveNameForAlgorithm();
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Open.IdentityServer.UnitTests.csproj
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Open.IdentityServer.UnitTests.csproj
@@ -12,18 +12,18 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
 
-        <PackageReference Include="xunit.v3"/>
-        <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All"/>
-        <PackageReference Include="AwesomeAssertions"/>
-        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing"/>
-        <PackageReference Include="Moq"/>
+        <PackageReference Include="xunit.v3" />
+        <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
+        <PackageReference Include="AwesomeAssertions" />
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+        <PackageReference Include="Moq" />
     </ItemGroup>
 
     <ItemGroup>
@@ -36,6 +36,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Open.IdentityServer.csproj"/>
+        <ProjectReference Include="..\..\src\Open.IdentityServer.csproj" />
     </ItemGroup>
 </Project>

--- a/src/Storage/src/Extensions/StringsExtensions.cs
+++ b/src/Storage/src/Extensions/StringsExtensions.cs
@@ -1,21 +1,25 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Modified by Rock Solid Knowledge Ltd. Copyright in modifications 2026, Rock Solid Knowledge Ltd.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+#nullable enable
 
 namespace Open.IdentityServer.Extensions;
 
 internal static class StringExtensions
 {
     [DebuggerStepThrough]
-    public static bool IsMissing(this string value)
+    public static bool IsMissing([NotNullWhen(false)] this string? value)
     {
         return string.IsNullOrWhiteSpace(value);
     }
 
     [DebuggerStepThrough]
-    public static bool IsPresent(this string value)
+    public static bool IsPresent([NotNullWhen(true)] this string? value)
     {
         return !string.IsNullOrWhiteSpace(value);
     }


### PR DESCRIPTION
## Description

Small nullable improvments of string extensions. I have not created any issue for this.
Small re-factoring of DataProtectedIdentityServerKeyMaterialConverter to make it more readable and parts of it more re-usable.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [X] Refactoring
- [ ] Documentation
- [X] Other

## Does this PR introduce a breaking change?

_Does the change cause existing functionality to not work as previously expected, or does the DB schema or C# public API surface change?_

- [ ] Yes
- [X] No


## LLM Usage

Co-pilot used to generate test data suggestions for unit tests.
