### PR TITLE
feat: improved prompt handling

### DIFF
--- a/docs/reference/options.rst
+++ b/docs/reference/options.rst
@@ -73,12 +73,14 @@ Allows setting length restrictions on various protocol parameters like client id
 UserInteraction
 ^^^^^^^^^^^^^^^
 
-* ``LoginUrl``, ``LogoutUrl``, ``ConsentUrl``, ``ErrorUrl``, ``DeviceVerificationUrl``
-    Sets the URLs for the login, logout, consent, error and device verification pages.
+* ``LoginUrl``, ``LogoutUrl``, ``CreateAccountUrl``, ``ConsentUrl``, ``ErrorUrl``, ``DeviceVerificationUrl``
+    Sets the URLs for the login, logout, create account, consent, error and device verification pages.
 * ``LoginReturnUrlParameter``
     Sets the name of the return URL parameter passed to the login page. Defaults to *returnUrl*.
 * ``LogoutIdParameter``
     Sets the name of the logout message id parameter passed to the logout page. Defaults to *logoutId*.
+* ``CreateAccountIdParameter``
+    Sets the name of the return URL parameter passed to the create account page. Defaults to *returnUrl*.
 * ``ConsentReturnUrlParameter``
     Sets the name of the return URL parameter passed to the consent page. Defaults to *returnUrl*.
 * ``ErrorIdParameter``
@@ -93,6 +95,10 @@ UserInteraction
     The value sets the maximum number of message cookies of any type that will be created.
     The oldest message cookies will be purged once the limit has been reached.
     This effectively indicates how many tabs can be opened by a user when using IdentityServer.
+* ``SupportedPromptModes``
+    Sets the prompt modes that are supported by IdentityServer. 
+    Defaults to *login*, *consent*, *select_account* and *none*.
+    When *CreateAccountUrl* is set, then *create* is also added to the supported prompt modes.
 
 Caching
 ^^^^^^^

--- a/docs/reference/options.rst
+++ b/docs/reference/options.rst
@@ -99,6 +99,7 @@ UserInteraction
     Sets the prompt modes that are supported by IdentityServer. 
     Defaults to *login*, *consent*, *select_account* and *none*.
     When *CreateAccountUrl* is set, then *create* is also added to the supported prompt modes.
+    Prompts that are not in this list will cause authorization requests to fail with an invalid_request error.
 
 Caching
 ^^^^^^^

--- a/src/Open.IdentityServer/src/Configuration/DependencyInjection/Options/UserInteractionOptions.cs
+++ b/src/Open.IdentityServer/src/Configuration/DependencyInjection/Options/UserInteractionOptions.cs
@@ -131,5 +131,5 @@ public class UserInteractionOptions
     /// <value>
     /// The supported prompt modes.
     /// </value>
-    public List<string> SupportedPromptModes { get; set; } = Constants.SupportedPromptModes;
+    public List<string> SupportedPromptModes { get; set; } = new(Constants.SupportedPromptModes);
 }

--- a/src/Open.IdentityServer/src/Configuration/DependencyInjection/Options/UserInteractionOptions.cs
+++ b/src/Open.IdentityServer/src/Configuration/DependencyInjection/Options/UserInteractionOptions.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Modified by Rock Solid Knowledge Ltd. Copyright in modifications 2026, Rock Solid Knowledge Ltd.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
 using Open.IdentityServer.Extensions;
+using System.Collections.Generic;
 
 namespace Open.IdentityServer.Configuration;
 
@@ -106,4 +108,28 @@ public class UserInteractionOptions
     /// The device verification user code parameter.
     /// </value>
     public string DeviceVerificationUserCodeParameter { get; set; } = Constants.UIConstants.DefaultRoutePathParams.UserCode;
+
+    /// <summary>
+    /// Gets or sets the create account URL. If a local URL, the value must start with a leading slash.
+    /// </summary>
+    /// <value>
+    /// The create account URL.
+    /// </value>
+    public string CreateAccountUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the create account return URL parameter.
+    /// </summary>
+    /// <value>
+    /// The create account return URL parameter.
+    /// </value>
+    public string CreateAccountReturnUrlParameter { get; set; } = Constants.UIConstants.DefaultRoutePathParams.CreateAccount;
+
+    /// <summary>
+    /// Gets or sets the supported prompt modes.
+    /// </summary>
+    /// <value>
+    /// The supported prompt modes.
+    /// </value>
+    public List<string> SupportedPromptModes { get; set; } = Constants.SupportedPromptModes;
 }

--- a/src/Open.IdentityServer/src/Configuration/DependencyInjection/Options/UserInteractionOptions.cs
+++ b/src/Open.IdentityServer/src/Configuration/DependencyInjection/Options/UserInteractionOptions.cs
@@ -126,7 +126,7 @@ public class UserInteractionOptions
     public string CreateAccountReturnUrlParameter { get; set; } = Constants.UIConstants.DefaultRoutePathParams.CreateAccount;
 
     /// <summary>
-    /// Gets or sets the supported prompt modes.
+    /// Gets or sets the supported prompt modes. Prompts that are not in this list will cause authorization requests to fail with an invalid_request error.
     /// </summary>
     /// <value>
     /// The supported prompt modes.

--- a/src/Open.IdentityServer/src/Configuration/IdentityServerApplicationBuilderExtensions.cs
+++ b/src/Open.IdentityServer/src/Configuration/IdentityServerApplicationBuilderExtensions.cs
@@ -1,4 +1,5 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Modified by Rock Solid Knowledge Ltd. Copyright in modifications 2026, Rock Solid Knowledge Ltd.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 

--- a/src/Open.IdentityServer/src/Configuration/IdentityServerApplicationBuilderExtensions.cs
+++ b/src/Open.IdentityServer/src/Configuration/IdentityServerApplicationBuilderExtensions.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Reflection;
 using System.Threading.Tasks;
+using Open.IdentityServer;
 
 namespace Microsoft.AspNetCore.Builder;
 
@@ -131,6 +132,12 @@ public static class IdentityServerApplicationBuilderExtensions
         if (options.UserInteraction.ConsentUrl.IsMissing()) throw new InvalidOperationException("ConsentUrl is not configured");
         if (options.UserInteraction.ConsentReturnUrlParameter.IsMissing()) throw new InvalidOperationException("ConsentReturnUrlParameter is not configured");
         if (options.UserInteraction.CustomRedirectReturnUrlParameter.IsMissing()) throw new InvalidOperationException("CustomRedirectReturnUrlParameter is not configured");
+
+        if (options.UserInteraction.CreateAccountUrl.IsPresent())
+        {
+            if (options.UserInteraction.CreateAccountReturnUrlParameter.IsMissing()) throw new InvalidOperationException("CreateAccountReturnUrlParameter is not configured");
+            options.UserInteraction.SupportedPromptModes.Add(OidcConstants.PromptModes.Create);
+        }
 
         if (options.Authentication.CheckSessionCookieName.IsMissing()) throw new InvalidOperationException("CheckSessionCookieName is not configured");
 

--- a/src/Open.IdentityServer/src/Constants.cs
+++ b/src/Open.IdentityServer/src/Constants.cs
@@ -113,6 +113,9 @@ internal static class Constants
         OidcConstants.PromptModes.SelectAccount
     };
 
+    public const string PromptProcessed = OidcConstants.AuthorizeRequest.Prompt + "_processed";
+    public const string MaxAgeProcessed = OidcConstants.AuthorizeRequest.MaxAge + "_processed";
+
     public static class KnownAcrValues
     {
         public const string HomeRealm = "idp:";

--- a/src/Open.IdentityServer/src/Constants.cs
+++ b/src/Open.IdentityServer/src/Constants.cs
@@ -177,6 +177,7 @@ internal static class Constants
         {
             public const string Error = "errorId";
             public const string Login = "returnUrl";
+            public const string CreateAccount = "returnUrl";
             public const string Consent = "returnUrl";
             public const string Logout = "logoutId";
             public const string EndSessionCallback = "endSessionId";

--- a/src/Open.IdentityServer/src/Constants.cs
+++ b/src/Open.IdentityServer/src/Constants.cs
@@ -113,8 +113,11 @@ internal static class Constants
         OidcConstants.PromptModes.SelectAccount
     };
 
-    public const string PromptProcessed = OidcConstants.AuthorizeRequest.Prompt + "_processed";
-    public const string MaxAgeProcessed = OidcConstants.AuthorizeRequest.MaxAge + "_processed";
+    public class ProcessedParameters
+    {
+        public const string PromptProcessed = OidcConstants.AuthorizeRequest.Prompt + "_processed";
+        public const string MaxAgeProcessed = OidcConstants.AuthorizeRequest.MaxAge + "_processed";
+    }
 
     public static class KnownAcrValues
     {

--- a/src/Open.IdentityServer/src/Endpoints/AuthorizeCallbackEndpoint.cs
+++ b/src/Open.IdentityServer/src/Endpoints/AuthorizeCallbackEndpoint.cs
@@ -76,8 +76,8 @@ internal class AuthorizeCallbackEndpoint : AuthorizeEndpointBase
 
         try
         {
-            parameters.Remove(OidcConstants.AuthorizeRequest.Prompt);
-            parameters.Remove(OidcConstants.AuthorizeRequest.MaxAge);
+            parameters.Add(Constants.PromptProcessed, "true");
+            parameters.Add(Constants.MaxAgeProcessed, "true");
 
             var result = await ProcessAuthorizeRequestAsync(parameters, user, consent?.Data);
 

--- a/src/Open.IdentityServer/src/Endpoints/AuthorizeCallbackEndpoint.cs
+++ b/src/Open.IdentityServer/src/Endpoints/AuthorizeCallbackEndpoint.cs
@@ -76,8 +76,9 @@ internal class AuthorizeCallbackEndpoint : AuthorizeEndpointBase
 
         try
         {
-            parameters.Add(Constants.PromptProcessed, "true");
-            parameters.Add(Constants.MaxAgeProcessed, "true");
+            // Add processed parameters to indicate that they have been processed
+            parameters.Add(Constants.ProcessedParameters.PromptProcessed, "true");
+            parameters.Add(Constants.ProcessedParameters.MaxAgeProcessed, "true");
 
             var result = await ProcessAuthorizeRequestAsync(parameters, user, consent?.Data);
 

--- a/src/Open.IdentityServer/src/Endpoints/AuthorizeCallbackEndpoint.cs
+++ b/src/Open.IdentityServer/src/Endpoints/AuthorizeCallbackEndpoint.cs
@@ -76,6 +76,9 @@ internal class AuthorizeCallbackEndpoint : AuthorizeEndpointBase
 
         try
         {
+            parameters.Remove(OidcConstants.AuthorizeRequest.Prompt);
+            parameters.Remove(OidcConstants.AuthorizeRequest.MaxAge);
+
             var result = await ProcessAuthorizeRequestAsync(parameters, user, consent?.Data);
 
             Logger.LogTrace("End Authorize Request. Result type: {0}", result?.GetType().ToString() ?? "-none-");

--- a/src/Open.IdentityServer/src/Endpoints/AuthorizeEndpointBase.cs
+++ b/src/Open.IdentityServer/src/Endpoints/AuthorizeEndpointBase.cs
@@ -95,6 +95,10 @@ internal abstract class AuthorizeEndpointBase : IEndpointHandler
         {
             return new LoginPageResult(request);
         }
+        if (interactionResult.IsCreateAccount)
+        {
+            return new CreateAccountPageResult(request);
+        }
         if (interactionResult.IsConsent)
         {
             return new ConsentPageResult(request);

--- a/src/Open.IdentityServer/src/Endpoints/Results/CreateAccountPageResult.cs
+++ b/src/Open.IdentityServer/src/Endpoints/Results/CreateAccountPageResult.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Rock Solid Knowledge Ltd. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+
+using System.Threading.Tasks;
+using Open.IdentityServer.Validation;
+using Open.IdentityServer.Extensions;
+using Open.IdentityServer.Configuration;
+using Open.IdentityServer.Stores;
+using Microsoft.AspNetCore.Http;
+
+namespace Open.IdentityServer.Endpoints.Results;
+
+/// <summary>
+/// Result for login page
+/// </summary>
+/// <seealso cref="Open.IdentityServer.Endpoints.Results.ReturnUrlResult" />
+public class CreateAccountPageResult : ReturnUrlResult
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CreateAccountPageResult"/> class.
+    /// </summary>
+    /// <param name="request">The request.</param>
+    /// <exception cref="System.ArgumentNullException">request</exception>
+    public CreateAccountPageResult(ValidatedAuthorizeRequest request):
+        base(request) { }
+
+    internal CreateAccountPageResult(
+        ValidatedAuthorizeRequest request,
+        IdentityServerOptions options,
+        IAuthorizationParametersMessageStore authorizationParametersMessageStore = null): 
+        base(request, options, authorizationParametersMessageStore) { }
+
+    /// <summary>
+    /// Executes the result.
+    /// </summary>
+    /// <param name="context">The HTTP context.</param>
+    public override async Task ExecuteAsync(HttpContext context)
+    {
+        Init(context);
+        var createUrl = Options.UserInteraction.CreateAccountUrl;
+        var returnUrl = await BuildReturnUrl(context, createUrl.IsLocalUrl());
+
+        var url = createUrl.AddQueryString(Options.UserInteraction.CreateAccountReturnUrlParameter, returnUrl);
+        context.Response.RedirectToAbsoluteUrl(url);
+    }
+}

--- a/src/Open.IdentityServer/src/Extensions/ValidatedAuthorizeRequestExtensions.cs
+++ b/src/Open.IdentityServer/src/Extensions/ValidatedAuthorizeRequestExtensions.cs
@@ -1,4 +1,5 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Modified by Rock Solid Knowledge Ltd. Copyright in modifications 2026, Rock Solid Knowledge Ltd.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 

--- a/src/Open.IdentityServer/src/Extensions/ValidatedAuthorizeRequestExtensions.cs
+++ b/src/Open.IdentityServer/src/Extensions/ValidatedAuthorizeRequestExtensions.cs
@@ -19,26 +19,6 @@ namespace Open.IdentityServer.Validation;
 public static class ValidatedAuthorizeRequestExtensions
 {
     /// <summary>
-    /// Removes the prompt parameter from the request.
-    /// </summary>
-    /// <param name="request">The validated authorize request.</param>
-    public static void RemovePrompt(this ValidatedAuthorizeRequest request)
-    {
-        request.PromptModes = Enumerable.Empty<string>();
-        request.Raw.Remove(OidcConstants.AuthorizeRequest.Prompt);
-    }
-
-    /// <summary>
-    /// Removes the max_age parameter from the request.
-    /// </summary>
-    /// <param name="request">The validated authorize request.</param>
-    public static void RemoveMaxAge(this ValidatedAuthorizeRequest request)
-    {
-        request.MaxAge = null;
-        request.Raw.Remove(OidcConstants.AuthorizeRequest.MaxAge);
-    }
-
-    /// <summary>
     /// Gets the first ACR value that starts with the specified prefix, with the prefix removed.
     /// </summary>
     /// <param name="request">The validated authorize request.</param>

--- a/src/Open.IdentityServer/src/Extensions/ValidatedAuthorizeRequestExtensions.cs
+++ b/src/Open.IdentityServer/src/Extensions/ValidatedAuthorizeRequestExtensions.cs
@@ -29,6 +29,16 @@ public static class ValidatedAuthorizeRequestExtensions
     }
 
     /// <summary>
+    /// Removes the max_age parameter from the request.
+    /// </summary>
+    /// <param name="request">The validated authorize request.</param>
+    public static void RemoveMaxAge(this ValidatedAuthorizeRequest request)
+    {
+        request.MaxAge = null;
+        request.Raw.Remove(OidcConstants.AuthorizeRequest.MaxAge);
+    }
+
+    /// <summary>
     /// Gets the first ACR value that starts with the specified prefix, with the prefix removed.
     /// </summary>
     /// <param name="request">The validated authorize request.</param>

--- a/src/Open.IdentityServer/src/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
+++ b/src/Open.IdentityServer/src/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
@@ -192,6 +192,10 @@ public class AuthorizeInteractionResponseGenerator : IAuthorizeInteractionRespon
             {
                 Logger.LogInformation("Showing login: Requested MaxAge exceeded.");
 
+                // remove max_age so when we redirect back in from login page
+                // we won't think we need to force a max_age again
+                request.RemoveMaxAge();
+
                 return new InteractionResponse { IsLogin = true };
             }
         }

--- a/src/Open.IdentityServer/src/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
+++ b/src/Open.IdentityServer/src/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
@@ -39,7 +39,7 @@ public class AuthorizeInteractionResponseGenerator : IAuthorizeInteractionRespon
     /// The clock
     /// </summary>
     protected readonly TimeProvider Clock;
-    
+
     /// <summary>
     /// The telemetry
     /// </summary>
@@ -56,7 +56,7 @@ public class AuthorizeInteractionResponseGenerator : IAuthorizeInteractionRespon
     public AuthorizeInteractionResponseGenerator(
         TimeProvider clock,
         ILogger<AuthorizeInteractionResponseGenerator> logger,
-        IConsentService consent, 
+        IConsentService consent,
         IProfileService profile,
         ITelemetryService telemetry)
     {
@@ -64,7 +64,7 @@ public class AuthorizeInteractionResponseGenerator : IAuthorizeInteractionRespon
         Logger = logger;
         Consent = consent;
         Profile = profile;
-        Telemetry =  telemetry;
+        Telemetry = telemetry;
     }
 
     /// <summary>
@@ -78,8 +78,8 @@ public class AuthorizeInteractionResponseGenerator : IAuthorizeInteractionRespon
         using var trace = Telemetry.Trace(TelemetryConstants.TraceCategories.Basic, this);
         Logger.LogTrace("ProcessInteractionAsync");
 
-        if (consent != null && 
-            consent.Granted == false && 
+        if (consent != null &&
+            consent.Granted == false &&
             consent.Error.HasValue)
         {
             // special case when anonymous user has issued an error prior to authenticating
@@ -93,7 +93,7 @@ public class AuthorizeInteractionResponseGenerator : IAuthorizeInteractionRespon
                 AuthorizationError.LoginRequired => OidcConstants.AuthorizeErrors.LoginRequired,
                 _ => OidcConstants.AuthorizeErrors.AccessDenied
             };
-                
+
             return new InteractionResponse
             {
                 Error = error,
@@ -101,11 +101,15 @@ public class AuthorizeInteractionResponseGenerator : IAuthorizeInteractionRespon
             };
         }
 
-        var result = await ProcessLoginAsync(request);
-            
-        if (!result.IsLogin && !result.IsError && !result.IsRedirect)
+        var result = await ProcessCreateAsync(request);
+        if (!result.IsCreateAccount && !result.IsError && !result.IsRedirect)
         {
-            result = await ProcessConsentAsync(request, consent);
+            result = await ProcessLoginAsync(request);
+
+            if (!result.IsLogin && !result.IsError && !result.IsRedirect)
+            {
+                result = await ProcessConsentAsync(request, consent);
+            }
         }
 
         if ((result.IsLogin || result.IsConsent || result.IsRedirect) && request.PromptModes.Contains(OidcConstants.PromptModes.None))
@@ -115,7 +119,7 @@ public class AuthorizeInteractionResponseGenerator : IAuthorizeInteractionRespon
             result = new InteractionResponse
             {
                 Error = result.IsLogin ? OidcConstants.AuthorizeErrors.LoginRequired :
-                    result.IsConsent ? OidcConstants.AuthorizeErrors.ConsentRequired : 
+                    result.IsConsent ? OidcConstants.AuthorizeErrors.ConsentRequired :
                     OidcConstants.AuthorizeErrors.InteractionRequired
             };
         }
@@ -134,13 +138,13 @@ public class AuthorizeInteractionResponseGenerator : IAuthorizeInteractionRespon
             request.PromptModes.Contains(OidcConstants.PromptModes.SelectAccount))
         {
             Logger.LogInformation("Showing login: request contains prompt={0}", request.PromptModes.ToSpaceSeparatedString());
-                
+
             return new InteractionResponse { IsLogin = true };
         }
 
         // unauthenticated user
         var isAuthenticated = request.Subject.IsAuthenticated();
-            
+
         // user de-activated
         bool isActive = false;
 
@@ -148,7 +152,7 @@ public class AuthorizeInteractionResponseGenerator : IAuthorizeInteractionRespon
         {
             var isActiveCtx = new IsActiveContext(request.Subject, request.Client, IdentityServerConstants.ProfileIsActiveCallers.AuthorizeEndpoint);
             await Profile.IsActiveAsync(isActiveCtx);
-                
+
             isActive = isActiveCtx.IsActive;
         }
 
@@ -202,7 +206,7 @@ public class AuthorizeInteractionResponseGenerator : IAuthorizeInteractionRespon
             }
         }
         // check external idp restrictions if user not using local idp
-        else if (request.Client.IdentityProviderRestrictions != null && 
+        else if (request.Client.IdentityProviderRestrictions != null &&
                  request.Client.IdentityProviderRestrictions.Any() &&
                  !request.Client.IdentityProviderRestrictions.Contains(currentIdp))
         {
@@ -225,6 +229,28 @@ public class AuthorizeInteractionResponseGenerator : IAuthorizeInteractionRespon
         }
 
         return new InteractionResponse();
+    }
+
+    /// <summary>
+    /// Processes the create account logic.
+    /// </summary>
+    /// <param name="request">The request.</param>
+    /// <returns>A task that resolves to an <see cref="InteractionResponse"/> indicating whether the create account screen should be shown.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="request"/> is <see langword="null"/>.</exception>
+    protected internal virtual Task<InteractionResponse> ProcessCreateAsync(ValidatedAuthorizeRequest request)
+    {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+
+        var response = new InteractionResponse();
+
+        if (request.PromptModes.Contains(OidcConstants.PromptModes.Create))
+        {
+            Logger.LogInformation("Showing create account: request contains prompt=create");
+
+            response.IsCreateAccount = true;
+        }
+
+        return Task.FromResult(response);
     }
 
     /// <summary>
@@ -290,7 +316,7 @@ public class AuthorizeInteractionResponseGenerator : IAuthorizeInteractionRespon
                         AuthorizationError.LoginRequired => OidcConstants.AuthorizeErrors.LoginRequired,
                         _ => OidcConstants.AuthorizeErrors.AccessDenied
                     };
-                        
+
                     response.Error = error;
                     response.ErrorDescription = consent.ErrorDescription;
                 }

--- a/src/Open.IdentityServer/src/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
+++ b/src/Open.IdentityServer/src/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
@@ -134,10 +134,6 @@ public class AuthorizeInteractionResponseGenerator : IAuthorizeInteractionRespon
             request.PromptModes.Contains(OidcConstants.PromptModes.SelectAccount))
         {
             Logger.LogInformation("Showing login: request contains prompt={0}", request.PromptModes.ToSpaceSeparatedString());
-
-            // remove prompt so when we redirect back in from login page
-            // we won't think we need to force a prompt again
-            request.RemovePrompt();
                 
             return new InteractionResponse { IsLogin = true };
         }
@@ -191,10 +187,6 @@ public class AuthorizeInteractionResponseGenerator : IAuthorizeInteractionRespon
             if (Clock.GetUtcNow() > authTime.AddSeconds(request.MaxAge.Value))
             {
                 Logger.LogInformation("Showing login: Requested MaxAge exceeded.");
-
-                // remove max_age so when we redirect back in from login page
-                // we won't think we need to force a max_age again
-                request.RemoveMaxAge();
 
                 return new InteractionResponse { IsLogin = true };
             }

--- a/src/Open.IdentityServer/src/ResponseHandling/Models/InteractionResponse.cs
+++ b/src/Open.IdentityServer/src/ResponseHandling/Models/InteractionResponse.cs
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Modified by Rock Solid Knowledge Ltd. Copyright in modifications 2026, Rock Solid Knowledge Ltd.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -18,6 +19,14 @@ public class InteractionResponse
     ///   <c>true</c> if this instance is login; otherwise, <c>false</c>.
     /// </value>
     public bool IsLogin { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the user should create an account.
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if this instance is create; otherwise, <c>false</c>.
+    /// </value>
+    public bool IsCreateAccount { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the user must consent.

--- a/src/Open.IdentityServer/src/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/Open.IdentityServer/src/Validation/Default/AuthorizeRequestValidator.cs
@@ -793,22 +793,18 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
         var maxAge = request.Raw.Get(OidcConstants.AuthorizeRequest.MaxAge);
         if (maxAge.IsPresent())
         {
-            // if max_age have been processed, aka validation is called in callback,
-            // then we don't want to prompt the user again, so skip handling of the parameter
-            var maxAgeProcessed = request.Raw.Get(Constants.ProcessedParameters.MaxAgeProcessed);
-
-            if (!maxAgeProcessed.IsPresent())
+            if (int.TryParse(maxAge, out var seconds))
             {
-                if (int.TryParse(maxAge, out var seconds))
+                if (seconds >= 0)
                 {
-                    if (seconds >= 0)
-                    {
+                    // if max_age have been processed, aka validation is called in callback,
+                    // then we don't want to prompt the user again in the case where max_age = 0,
+                    // so skip handling of the parameter
+                    var maxAgeProcessed = request.Raw.Get(Constants.ProcessedParameters.MaxAgeProcessed);
+
+                    if (!(seconds == 0 && maxAgeProcessed.IsPresent()))
+                    { 
                         request.MaxAge = seconds;
-                    }
-                    else
-                    {
-                        LogError("Invalid max_age.", request);
-                        return Invalid(request, description: "Invalid max_age");
                     }
                 }
                 else
@@ -816,6 +812,11 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
                     LogError("Invalid max_age.", request);
                     return Invalid(request, description: "Invalid max_age");
                 }
+            }
+            else
+            {
+                LogError("Invalid max_age.", request);
+                return Invalid(request, description: "Invalid max_age");
             }
         }
 

--- a/src/Open.IdentityServer/src/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/Open.IdentityServer/src/Validation/Default/AuthorizeRequestValidator.cs
@@ -746,7 +746,8 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
             }
             else
             {
-                _logger.LogDebug("Unsupported prompt mode - ignored: " + prompt);
+                LogError("prompt contains unsupported values " + prompt, request);
+                return Invalid(request, description: "Invalid prompt");
             }
         }
 

--- a/src/Open.IdentityServer/src/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/Open.IdentityServer/src/Validation/Default/AuthorizeRequestValidator.cs
@@ -727,7 +727,9 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
         var prompt = request.Raw.Get(OidcConstants.AuthorizeRequest.Prompt);
         if (prompt.IsPresent())
         {
-            var promptProcessed = request.Raw.Get(Constants.PromptProcessed);
+            // if prompt have been processed, aka validation is called in callback,
+            // then we don't want to prompt the user again, so skip handling of the parameter
+            var promptProcessed = request.Raw.Get(Constants.ProcessedParameters.PromptProcessed);
 
             if (!promptProcessed.IsPresent())
             {
@@ -791,7 +793,9 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
         var maxAge = request.Raw.Get(OidcConstants.AuthorizeRequest.MaxAge);
         if (maxAge.IsPresent())
         {
-            var maxAgeProcessed = request.Raw.Get(Constants.MaxAgeProcessed);
+            // if max_age have been processed, aka validation is called in callback,
+            // then we don't want to prompt the user again, so skip handling of the parameter
+            var maxAgeProcessed = request.Raw.Get(Constants.ProcessedParameters.MaxAgeProcessed);
 
             if (!maxAgeProcessed.IsPresent())
             {

--- a/src/Open.IdentityServer/src/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/Open.IdentityServer/src/Validation/Default/AuthorizeRequestValidator.cs
@@ -727,27 +727,32 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
         var prompt = request.Raw.Get(OidcConstants.AuthorizeRequest.Prompt);
         if (prompt.IsPresent())
         {
-            var prompts = prompt.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-            if (prompts.All(p => _options.UserInteraction.SupportedPromptModes.Contains(p)))
+            var promptProcessed = request.Raw.Get(Constants.PromptProcessed);
+
+            if (!promptProcessed.IsPresent())
             {
-                if (prompts.Contains(OidcConstants.PromptModes.None) && prompts.Length > 1)
+                var prompts = prompt.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                if (prompts.All(p => _options.UserInteraction.SupportedPromptModes.Contains(p)))
                 {
-                    LogError("prompt contains 'none' and other values. 'none' should be used by itself.", request);
+                    if (prompts.Contains(OidcConstants.PromptModes.None) && prompts.Length > 1)
+                    {
+                        LogError("prompt contains 'none' and other values. 'none' should be used by itself.", request);
+                        return Invalid(request, description: "Invalid prompt");
+                    }
+
+                    if (prompts.Contains(OidcConstants.PromptModes.Create) && prompts.Length > 1)
+                    {
+                        LogError("prompt contains 'create' and other values. 'create' should be used by itself.", request);
+                        return Invalid(request, description: "Invalid prompt");
+                    }
+
+                    request.PromptModes = prompts;
+                }
+                else
+                {
+                    LogError("prompt contains unsupported values " + prompt, request);
                     return Invalid(request, description: "Invalid prompt");
                 }
-
-                if (prompts.Contains(OidcConstants.PromptModes.Create) && prompts.Length > 1)
-                {
-                    LogError("prompt contains 'create' and other values. 'create' should be used by itself.", request);
-                    return Invalid(request, description: "Invalid prompt");
-                }
-
-                request.PromptModes = prompts;
-            }
-            else
-            {
-                LogError("prompt contains unsupported values " + prompt, request);
-                return Invalid(request, description: "Invalid prompt");
             }
         }
 
@@ -786,22 +791,27 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
         var maxAge = request.Raw.Get(OidcConstants.AuthorizeRequest.MaxAge);
         if (maxAge.IsPresent())
         {
-            if (int.TryParse(maxAge, out var seconds))
+            var maxAgeProcessed = request.Raw.Get(Constants.MaxAgeProcessed);
+
+            if (!maxAgeProcessed.IsPresent())
             {
-                if (seconds >= 0)
+                if (int.TryParse(maxAge, out var seconds))
                 {
-                    request.MaxAge = seconds;
+                    if (seconds >= 0)
+                    {
+                        request.MaxAge = seconds;
+                    }
+                    else
+                    {
+                        LogError("Invalid max_age.", request);
+                        return Invalid(request, description: "Invalid max_age");
+                    }
                 }
                 else
                 {
                     LogError("Invalid max_age.", request);
                     return Invalid(request, description: "Invalid max_age");
                 }
-            }
-            else
-            {
-                LogError("Invalid max_age.", request);
-                return Invalid(request, description: "Invalid max_age");
             }
         }
 

--- a/src/Open.IdentityServer/src/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/Open.IdentityServer/src/Validation/Default/AuthorizeRequestValidator.cs
@@ -727,34 +727,38 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
         var prompt = request.Raw.Get(OidcConstants.AuthorizeRequest.Prompt);
         if (prompt.IsPresent())
         {
+            var prompts = prompt.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            if (prompts.All(p => _options.UserInteraction.SupportedPromptModes.Contains(p)))
+            {
+                if (prompts.Contains(OidcConstants.PromptModes.None) && prompts.Length > 1)
+                {
+                    LogError("prompt contains 'none' and other values. 'none' should be used by itself.", request);
+                    return Invalid(request, description: "Invalid prompt");
+                }
+
+                if (prompts.Contains(OidcConstants.PromptModes.Create) && prompts.Length > 1)
+                {
+                    LogError("prompt contains 'create' and other values. 'create' should be used by itself.", request);
+                    return Invalid(request, description: "Invalid prompt");
+                }
+            }
+            else
+            {
+                LogError("prompt contains unsupported values " + prompt, request);
+                return Invalid(request, description: "Invalid prompt");
+            }
+
             // if prompt have been processed, aka validation is called in callback,
             // then we don't want to prompt the user again, so skip handling of the parameter
             var promptProcessed = request.Raw.Get(Constants.ProcessedParameters.PromptProcessed);
 
-            if (!promptProcessed.IsPresent())
+            if (promptProcessed.IsPresent())
             {
-                var prompts = prompt.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-                if (prompts.All(p => _options.UserInteraction.SupportedPromptModes.Contains(p)))
-                {
-                    if (prompts.Contains(OidcConstants.PromptModes.None) && prompts.Length > 1)
-                    {
-                        LogError("prompt contains 'none' and other values. 'none' should be used by itself.", request);
-                        return Invalid(request, description: "Invalid prompt");
-                    }
-
-                    if (prompts.Contains(OidcConstants.PromptModes.Create) && prompts.Length > 1)
-                    {
-                        LogError("prompt contains 'create' and other values. 'create' should be used by itself.", request);
-                        return Invalid(request, description: "Invalid prompt");
-                    }
-
-                    request.PromptModes = prompts;
-                }
-                else
-                {
-                    LogError("prompt contains unsupported values " + prompt, request);
-                    return Invalid(request, description: "Invalid prompt");
-                }
+                request.ProcessedPromptModes = prompts;
+            }
+            else
+            {
+                request.PromptModes = prompts;
             }
         }
 
@@ -803,7 +807,7 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
                     var maxAgeProcessed = request.Raw.Get(Constants.ProcessedParameters.MaxAgeProcessed);
 
                     if (!(seconds == 0 && maxAgeProcessed.IsPresent()))
-                    { 
+                    {
                         request.MaxAge = seconds;
                     }
                 }

--- a/src/Open.IdentityServer/src/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/Open.IdentityServer/src/Validation/Default/AuthorizeRequestValidator.cs
@@ -728,7 +728,7 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
         if (prompt.IsPresent())
         {
             var prompts = prompt.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-            if (prompts.All(p => Constants.SupportedPromptModes.Contains(p)))
+            if (prompts.All(p => _options.UserInteraction.SupportedPromptModes.Contains(p)))
             {
                 if (prompts.Contains(OidcConstants.PromptModes.None) && prompts.Length > 1)
                 {

--- a/src/Open.IdentityServer/src/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/Open.IdentityServer/src/Validation/Default/AuthorizeRequestValidator.cs
@@ -736,6 +736,12 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
                     return Invalid(request, description: "Invalid prompt");
                 }
 
+                if (prompts.Contains(OidcConstants.PromptModes.Create) && prompts.Length > 1)
+                {
+                    LogError("prompt contains 'create' and other values. 'create' should be used by itself.", request);
+                    return Invalid(request, description: "Invalid prompt");
+                }
+
                 request.PromptModes = prompts;
             }
             else

--- a/src/Open.IdentityServer/src/Validation/Models/ValidatedAuthorizeRequest.cs
+++ b/src/Open.IdentityServer/src/Validation/Models/ValidatedAuthorizeRequest.cs
@@ -142,6 +142,15 @@ public class ValidatedAuthorizeRequest : ValidatedRequest
     public IEnumerable<string> PromptModes { get; set; } = Enumerable.Empty<string>();
 
     /// <summary>
+    /// Gets or sets the collection of processed prompt modes.
+    /// </summary>
+    /// <remarks>
+    /// A prompt is processed if it has been handled by the authorization endpoint and should not be processed again. 
+    /// This is used to prevent infinite loops when the user is redirected back to the authorization endpoint after a prompt has been handled.
+    /// </remarks>
+    public IEnumerable<string> ProcessedPromptModes { get; set; } = Enumerable.Empty<string>();
+
+    /// <summary>
     /// Gets or sets the maximum age.
     /// </summary>
     /// <value>

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
@@ -1,4 +1,5 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Modified by Rock Solid Knowledge Ltd. Copyright in modifications 2026, Rock Solid Knowledge Ltd.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 #nullable enable

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
@@ -187,6 +187,7 @@ public class IdentityServerPipeline
     }
 
     public bool LoginWasCalled { get; set; }
+    public string? LoginReturnUrl { get; set; }
     public AuthorizationRequest? LoginRequest { get; set; }
     public ClaimsPrincipal? Subject { get; set; }
     public bool FollowLoginReturnUrl { get; set; }
@@ -201,7 +202,8 @@ public class IdentityServerPipeline
     private async Task ReadLoginRequest(HttpContext ctx)
     {
         var interaction = ctx.RequestServices.GetRequiredService<IIdentityServerInteractionService>();
-        LoginRequest = await interaction.GetAuthorizationContextAsync(ctx.Request.Query["returnUrl"].FirstOrDefault());
+        LoginReturnUrl = ctx.Request.Query["returnUrl"].FirstOrDefault();
+        LoginRequest = await interaction.GetAuthorizationContextAsync(LoginReturnUrl);
     }
 
     private async Task IssueLoginCookie(HttpContext ctx)

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
@@ -36,6 +36,8 @@ public class IdentityServerPipeline
     public const string LoginPage = BaseUrl + "/account/login";
     public const string ConsentPage = BaseUrl + "/account/consent";
     public const string ErrorPage = BaseUrl + "/home/error";
+    public const string CreatePageRelative = "/account/create";
+    public const string CreatePage = BaseUrl + CreatePageRelative;
 
     public const string DeviceAuthorization = BaseUrl + "/connect/deviceauthorization";
     public const string DiscoveryEndpoint = BaseUrl + "/.well-known/openid-configuration";
@@ -182,6 +184,10 @@ public class IdentityServerPipeline
         {
             path.Run(ctx => OnError(ctx));
         });
+        app.Map(CreatePageRelative, path =>
+        {
+            path.Run(ctx => OnCreate(ctx));
+        });
 
         OnPostConfigure(app);
     }
@@ -277,6 +283,21 @@ public class IdentityServerPipeline
     {
         ErrorWasCalled = true;
         await ReadErrorMessage(ctx);
+    }
+
+    public bool CreateWasCalled { get; set; }
+    public AuthorizationRequest? CreateRequest { get; set; }
+
+    private async Task OnCreate(HttpContext ctx)
+    {
+        CreateWasCalled = true;
+        await ReadCreateMessage(ctx);
+    }
+
+    private async Task ReadCreateMessage(HttpContext ctx)
+    {
+        var interaction = ctx.RequestServices.GetRequiredService<IIdentityServerInteractionService>();
+        CreateRequest = await interaction.GetAuthorizationContextAsync(ctx.Request.Query["returnUrl"].FirstOrDefault());
     }
 
     private async Task ReadErrorMessage(HttpContext ctx)

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
@@ -1,4 +1,5 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Modified by Rock Solid Knowledge Ltd. Copyright in modifications 2026, Rock Solid Knowledge Ltd.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
@@ -1169,6 +1169,29 @@ public class AuthorizeTests
 
     [Fact]
     [Trait("Category", Category)]
+    public async Task prompt_login_and_create_should_return_error()
+    {
+        await _mockPipeline.LoginAsync("bob");
+
+        var url = _mockPipeline.CreateAuthorizeUrl(
+            clientId: "client1",
+            responseType: "id_token",
+            scope: "openid profile",
+            redirectUri: "https://client1/callback",
+            state: "123_state",
+            nonce: "123_nonce",
+            extra: new Parameters
+            {
+                { "prompt", "login create" },
+            }
+        );
+        await _mockPipeline.BrowserClient.GetAsync(url, TestContext.Current.CancellationToken);
+
+        _mockPipeline.ErrorWasCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
     public async Task prompt_login_should_show_login_page()
     {
         await _mockPipeline.LoginAsync("bob");

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
@@ -1297,7 +1297,7 @@ public class AuthorizeTests
         await _mockPipeline.BrowserClient.GetAsync(url, TestContext.Current.CancellationToken);
 
         _mockPipeline.BrowserClient.AllowAutoRedirect = false;
-        var response = await _mockPipeline.BrowserClient.GetAsync(IdentityServerPipeline.BaseUrl + _mockPipeline.LoginReturnUrl);
+        var response = await _mockPipeline.BrowserClient.GetAsync(IdentityServerPipeline.BaseUrl + _mockPipeline.LoginReturnUrl, TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.Redirect);
         response.Headers.Location.ToString().Should().StartWith("https://client1/callback");
         response.Headers.Location.ToString().Should().Contain("id_token=");
@@ -1348,7 +1348,7 @@ public class AuthorizeTests
         await _mockPipeline.BrowserClient.GetAsync(url, TestContext.Current.CancellationToken);
 
         _mockPipeline.BrowserClient.AllowAutoRedirect = false;
-        var response = await _mockPipeline.BrowserClient.GetAsync(IdentityServerPipeline.BaseUrl + _mockPipeline.LoginReturnUrl);
+        var response = await _mockPipeline.BrowserClient.GetAsync(IdentityServerPipeline.BaseUrl + _mockPipeline.LoginReturnUrl, TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.Redirect);
         response.Headers.Location.ToString().Should().StartWith("https://client1/callback");
         response.Headers.Location.ToString().Should().Contain("id_token=");

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
@@ -1182,7 +1182,30 @@ public class AuthorizeTests
             nonce: "123_nonce",
             extra: new Parameters
             {
-                { "popup", "login" },
+                { "prompt", "login" },
+            }
+        );
+        await _mockPipeline.BrowserClient.GetAsync(url, TestContext.Current.CancellationToken);
+
+        _mockPipeline.LoginWasCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task max_age_0_should_show_login_page()
+    {
+        await _mockPipeline.LoginAsync("bob");
+
+        var url = _mockPipeline.CreateAuthorizeUrl(
+            clientId: "client3",
+            responseType: "id_token",
+            scope: "openid profile",
+            redirectUri: "https://client3/callback",
+            state: "123_state",
+            nonce: "123_nonce",
+            extra: new Parameters
+            {
+                { "max_age", "0" },
             }
         );
         await _mockPipeline.BrowserClient.GetAsync(url, TestContext.Current.CancellationToken);

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
@@ -1188,6 +1188,7 @@ public class AuthorizeTests
         await _mockPipeline.BrowserClient.GetAsync(url, TestContext.Current.CancellationToken);
 
         _mockPipeline.LoginWasCalled.Should().BeTrue();
+        _mockPipeline.LoginRequest.PromptModes.Should().Contain("login");
     }
 
     [Fact]
@@ -1238,6 +1239,7 @@ public class AuthorizeTests
         await _mockPipeline.BrowserClient.GetAsync(url, TestContext.Current.CancellationToken);
 
         _mockPipeline.LoginWasCalled.Should().BeTrue();
+        _mockPipeline.LoginRequest.Parameters.Get(OidcConstants.AuthorizeRequest.MaxAge).Should().Be("0");
     }
 
     [Fact]

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
@@ -18,6 +18,7 @@ using Open.IdentityServer.Stores.Default;
 using Open.IdentityServer.Test;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
+using Open.IdentityServer.Configuration;
 
 namespace IdentityServer.IntegrationTests.Endpoints.Authorize;
 
@@ -1166,11 +1167,19 @@ public class AuthorizeTests
         _mockPipeline.LoginWasCalled.Should().BeTrue();
     }
 
-
     [Fact]
     [Trait("Category", Category)]
-    public async Task prompt_login_and_create_should_return_error()
+    public async Task prompt_create_and_login_should_return_error()
     {
+        _mockPipeline.OnPreConfigureServices += services =>
+        {
+            services.PostConfigure<IdentityServerOptions>(options =>
+            {
+                options.UserInteraction.SupportedPromptModes.Add(OidcConstants.PromptModes.Create);
+            });
+        };
+        _mockPipeline.Initialize();
+
         await _mockPipeline.LoginAsync("bob");
 
         var url = _mockPipeline.CreateAuthorizeUrl(
@@ -1182,12 +1191,43 @@ public class AuthorizeTests
             nonce: "123_nonce",
             extra: new Parameters
             {
-                { "prompt", "login create" },
+                { "prompt", "create login" },
             }
         );
         await _mockPipeline.BrowserClient.GetAsync(url, TestContext.Current.CancellationToken);
 
         _mockPipeline.ErrorWasCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task prompt_create_should_show_login_page()
+    {
+        _mockPipeline.OnPreConfigureServices += services =>
+        {
+            services.PostConfigure<IdentityServerOptions>(options =>
+            {
+                options.UserInteraction.CreateAccountUrl = IdentityServerPipeline.CreatePageRelative;
+            });
+        };
+        _mockPipeline.Initialize();
+
+        var url = _mockPipeline.CreateAuthorizeUrl(
+            clientId: "client1",
+            responseType: "id_token",
+            scope: "openid profile",
+            redirectUri: "https://client1/callback",
+            state: "123_state",
+            nonce: "123_nonce",
+            extra: new Parameters
+            {
+                { "prompt", "create" },
+            }
+        );
+        await _mockPipeline.BrowserClient.GetAsync(url, TestContext.Current.CancellationToken);
+
+        _mockPipeline.CreateWasCalled.Should().BeTrue();
+        _mockPipeline.CreateRequest.PromptModes.Should().Contain("create");
     }
 
     [Fact]

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
@@ -1169,6 +1169,27 @@ public class AuthorizeTests
 
     [Fact]
     [Trait("Category", Category)]
+    public async Task unsupported_prompt_should_return_error()
+    {
+        var url = _mockPipeline.CreateAuthorizeUrl(
+            clientId: "client1",
+            responseType: "id_token",
+            scope: "openid profile",
+            redirectUri: "https://client1/callback",
+            state: "123_state",
+            nonce: "123_nonce",
+            extra: new Parameters
+            {
+                { "prompt", "unsupported" },
+            }
+        );
+        await _mockPipeline.BrowserClient.GetAsync(url, TestContext.Current.CancellationToken);
+
+        _mockPipeline.ErrorWasCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
     public async Task prompt_create_and_login_should_return_error()
     {
         _mockPipeline.OnPreConfigureServices += services =>

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
@@ -1170,59 +1170,6 @@ public class AuthorizeTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task unsupported_prompt_should_return_error()
-    {
-        var url = _mockPipeline.CreateAuthorizeUrl(
-            clientId: "client1",
-            responseType: "id_token",
-            scope: "openid profile",
-            redirectUri: "https://client1/callback",
-            state: "123_state",
-            nonce: "123_nonce",
-            extra: new Parameters
-            {
-                { "prompt", "unsupported" },
-            }
-        );
-        await _mockPipeline.BrowserClient.GetAsync(url, TestContext.Current.CancellationToken);
-
-        _mockPipeline.ErrorWasCalled.Should().BeTrue();
-    }
-
-    [Fact]
-    [Trait("Category", Category)]
-    public async Task prompt_create_and_login_should_return_error()
-    {
-        _mockPipeline.OnPreConfigureServices += services =>
-        {
-            services.PostConfigure<IdentityServerOptions>(options =>
-            {
-                options.UserInteraction.SupportedPromptModes.Add(OidcConstants.PromptModes.Create);
-            });
-        };
-        _mockPipeline.Initialize();
-
-        await _mockPipeline.LoginAsync("bob");
-
-        var url = _mockPipeline.CreateAuthorizeUrl(
-            clientId: "client1",
-            responseType: "id_token",
-            scope: "openid profile",
-            redirectUri: "https://client1/callback",
-            state: "123_state",
-            nonce: "123_nonce",
-            extra: new Parameters
-            {
-                { "prompt", "create login" },
-            }
-        );
-        await _mockPipeline.BrowserClient.GetAsync(url, TestContext.Current.CancellationToken);
-
-        _mockPipeline.ErrorWasCalled.Should().BeTrue();
-    }
-
-    [Fact]
-    [Trait("Category", Category)]
     public async Task prompt_create_should_show_create_account_page()
     {
         _mockPipeline.OnPreConfigureServices += services =>

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
@@ -1174,10 +1174,10 @@ public class AuthorizeTests
         await _mockPipeline.LoginAsync("bob");
 
         var url = _mockPipeline.CreateAuthorizeUrl(
-            clientId: "client3",
+            clientId: "client1",
             responseType: "id_token",
             scope: "openid profile",
-            redirectUri: "https://client3/callback",
+            redirectUri: "https://client1/callback",
             state: "123_state",
             nonce: "123_nonce",
             extra: new Parameters
@@ -1192,15 +1192,42 @@ public class AuthorizeTests
 
     [Fact]
     [Trait("Category", Category)]
+    public async Task prompt_login_should_allow_user_to_login_and_return()
+    {
+        await _mockPipeline.LoginAsync("bob");
+
+        var url = _mockPipeline.CreateAuthorizeUrl(
+            clientId: "client1",
+            responseType: "id_token",
+            scope: "openid profile",
+            redirectUri: "https://client1/callback",
+            state: "123_state",
+            nonce: "123_nonce",
+            extra: new Parameters
+            {
+                { "prompt", "login" },
+            }
+        );
+        await _mockPipeline.BrowserClient.GetAsync(url, TestContext.Current.CancellationToken);
+
+        _mockPipeline.BrowserClient.AllowAutoRedirect = false;
+        var response = await _mockPipeline.BrowserClient.GetAsync(IdentityServerPipeline.BaseUrl + _mockPipeline.LoginReturnUrl);
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response.Headers.Location.ToString().Should().StartWith("https://client1/callback");
+        response.Headers.Location.ToString().Should().Contain("id_token=");
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
     public async Task max_age_0_should_show_login_page()
     {
         await _mockPipeline.LoginAsync("bob");
 
         var url = _mockPipeline.CreateAuthorizeUrl(
-            clientId: "client3",
+            clientId: "client1",
             responseType: "id_token",
             scope: "openid profile",
-            redirectUri: "https://client3/callback",
+            redirectUri: "https://client1/callback",
             state: "123_state",
             nonce: "123_nonce",
             extra: new Parameters
@@ -1211,5 +1238,32 @@ public class AuthorizeTests
         await _mockPipeline.BrowserClient.GetAsync(url, TestContext.Current.CancellationToken);
 
         _mockPipeline.LoginWasCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task max_age_0_should_allow_user_to_login_and_return()
+    {
+        await _mockPipeline.LoginAsync("bob");
+
+        var url = _mockPipeline.CreateAuthorizeUrl(
+            clientId: "client1",
+            responseType: "id_token",
+            scope: "openid profile",
+            redirectUri: "https://client1/callback",
+            state: "123_state",
+            nonce: "123_nonce",
+            extra: new Parameters
+            {
+                { "max_age", "0" },
+            }
+        );
+        await _mockPipeline.BrowserClient.GetAsync(url, TestContext.Current.CancellationToken);
+
+        _mockPipeline.BrowserClient.AllowAutoRedirect = false;
+        var response = await _mockPipeline.BrowserClient.GetAsync(IdentityServerPipeline.BaseUrl + _mockPipeline.LoginReturnUrl);
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response.Headers.Location.ToString().Should().StartWith("https://client1/callback");
+        response.Headers.Location.ToString().Should().Contain("id_token=");
     }
 }

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
@@ -1223,7 +1223,7 @@ public class AuthorizeTests
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task prompt_create_should_show_login_page()
+    public async Task prompt_create_should_show_create_account_page()
     {
         _mockPipeline.OnPreConfigureServices += services =>
         {

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/JwtRequestAuthorizeTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/JwtRequestAuthorizeTests.cs
@@ -2,25 +2,26 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
+using AwesomeAssertions;
+using IdentityServer.IntegrationTests.Common;
+using IdentityServer.IntegrationTests.Utility;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Logging;
+using Microsoft.IdentityModel.Tokens;
+using Open.IdentityServer;
+using Open.IdentityServer.Configuration;
+using Open.IdentityServer.Models;
+using Open.IdentityServer.Test;
+using Open.IdentityServer.Utility;
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
 using System.Threading.Tasks;
-using AwesomeAssertions;
-using IdentityServer.IntegrationTests.Common;
-using IdentityServer.IntegrationTests.Utility;
-using Open.IdentityServer;
-using Open.IdentityServer.Configuration;
-using Open.IdentityServer.Models;
-using Open.IdentityServer.Test;
-using Microsoft.IdentityModel.JsonWebTokens;
-using Microsoft.IdentityModel.Logging;
-using Microsoft.IdentityModel.Tokens;
-using Open.IdentityServer.Utility;
 using Xunit;
 
 namespace IdentityServer.IntegrationTests.Endpoints.Authorize;
@@ -1168,5 +1169,45 @@ public class JwtRequestAuthorizeTests
         _mockPipeline.LoginRequest.Should().BeNull();
 
         _mockPipeline.JwtRequestMessageHandler.InvokeWasCalled.Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task prompt_login_should_allow_user_to_login_and_return()
+    {
+        _mockPipeline.Options.Endpoints.EnableJwtRequestUri = true;
+
+        var requestJwt = CreateRequestJwt(
+            issuer: _client.ClientId,
+            audience: IdentityServerPipeline.BaseUrl,
+            credential: new X509SigningCredentials(TestCert.Load()),
+            claims:
+            [
+                new Claim("client_id", _client.ClientId),
+                new Claim("response_type", "id_token"),
+                new Claim("scope", "openid profile"),
+                new Claim("state", "123state"),
+                new Claim("nonce", "123nonce"),
+                new Claim("redirect_uri", "https://client/callback"),
+                new Claim("prompt", "login")
+            ]);
+        _mockPipeline.JwtRequestMessageHandler.Response.Content = new StringContent(requestJwt);
+
+        await _mockPipeline.LoginAsync("bob");
+
+        var url = _mockPipeline.CreateAuthorizeUrl(
+            clientId: _client.ClientId,
+            responseType: "id_token",
+            extra: new Parameters
+            {
+                { "request", requestJwt }
+            });
+        var response = await _mockPipeline.BrowserClient.GetAsync(url, TestContext.Current.CancellationToken);
+
+        _mockPipeline.BrowserClient.AllowAutoRedirect = false;
+        response = await _mockPipeline.BrowserClient.GetAsync(IdentityServerPipeline.BaseUrl + _mockPipeline.LoginReturnUrl);
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response.Headers.Location.ToString().Should().StartWith("https://client/callback");
+        response.Headers.Location.ToString().Should().Contain("id_token=");
     }
 }

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/JwtRequestAuthorizeTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Endpoints/Authorize/JwtRequestAuthorizeTests.cs
@@ -1205,7 +1205,7 @@ public class JwtRequestAuthorizeTests
         var response = await _mockPipeline.BrowserClient.GetAsync(url, TestContext.Current.CancellationToken);
 
         _mockPipeline.BrowserClient.AllowAutoRedirect = false;
-        response = await _mockPipeline.BrowserClient.GetAsync(IdentityServerPipeline.BaseUrl + _mockPipeline.LoginReturnUrl);
+        response = await _mockPipeline.BrowserClient.GetAsync(IdentityServerPipeline.BaseUrl + _mockPipeline.LoginReturnUrl, TestContext.Current.CancellationToken);
         response.StatusCode.Should().Be(HttpStatusCode.Redirect);
         response.Headers.Location.ToString().Should().StartWith("https://client/callback");
         response.Headers.Location.ToString().Should().Contain("id_token=");

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Configuration/IdentityServerApplicationBuilderExtensionsTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Configuration/IdentityServerApplicationBuilderExtensionsTests.cs
@@ -1,0 +1,267 @@
+﻿// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Open.IdentityServer.Configuration;
+using Open.IdentityServer.Stores;
+using Xunit;
+
+namespace Open.IdentityServer.UnitTests.Configuration;
+
+public class IdentityServerApplicationBuilderExtensionsTests
+{
+    [Fact]
+    public void UseIdentityServer_WhenRequiredServicesAreRegistered_ShouldNotThrow()
+    {
+        var app = BuildAppBuilder();
+
+        Action act = () => app.UseIdentityServer(CreateNoOpMiddlewareOptions());
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void UseIdentityServer_WithLoggerFactoryMissing_ShouldThrowArgumentNullException()
+    {
+        var app = BuildAppBuilder(registerLoggerFactory: false);
+
+        Action act = () => app.UseIdentityServer(CreateNoOpMiddlewareOptions());
+
+        act.Should().Throw<ArgumentNullException>()
+            .WithParameterName("loggerFactory");
+    }
+
+    [Fact]
+    public void UseIdentityServer_WithPersistedGrantStoreMissing_ShouldThrowInvalidOperationException()
+    {
+        var app = BuildAppBuilder(registerPersistedGrantStore: false);
+
+        Action act = () => app.UseIdentityServer(CreateNoOpMiddlewareOptions());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("No storage mechanism for grants specified. Use the 'AddInMemoryPersistedGrants' extension method to register a development version.");
+    }
+
+    [Fact]
+    public void UseIdentityServer_WithClientStoreMissing_ShouldThrowInvalidOperationException()
+    {
+        var app = BuildAppBuilder(registerClientStore: false);
+
+        Action act = () => app.UseIdentityServer(CreateNoOpMiddlewareOptions());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("No storage mechanism for clients specified. Use the 'AddInMemoryClients' extension method to register a development version.");
+    }
+
+    [Fact]
+    public void UseIdentityServer_WithResourceStoreMissing_ShouldThrowInvalidOperationException()
+    {
+        var app = BuildAppBuilder(registerResourceStore: false);
+
+        Action act = () => app.UseIdentityServer(CreateNoOpMiddlewareOptions());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("No storage mechanism for resources specified. Use the 'AddInMemoryIdentityResources' or 'AddInMemoryApiResources' extension method to register a development version.");
+    }
+
+    [Fact]
+    public void UseIdentityServer_WithLogoutIdParameterMissing_ShouldThrowInvalidOperationException()
+    {
+        var options = new IdentityServerOptions();
+        options.UserInteraction.LogoutIdParameter = null;
+
+        var app = BuildAppBuilder(identityServerOptions: options);
+
+        Action act = () => app.UseIdentityServer(CreateNoOpMiddlewareOptions());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("LogoutIdParameter is not configured");
+    }
+
+    [Fact]
+    public void UseIdentityServer_WithErrorUrlMissing_ShouldThrowInvalidOperationException()
+    {
+        var options = new IdentityServerOptions();
+        options.UserInteraction.ErrorUrl = null;
+
+        var app = BuildAppBuilder(identityServerOptions: options);
+
+        Action act = () => app.UseIdentityServer(CreateNoOpMiddlewareOptions());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("ErrorUrl is not configured");
+    }
+
+    [Fact]
+    public void UseIdentityServer_WithErrorIdParameterMissing_ShouldThrowInvalidOperationException()
+    {
+        var options = new IdentityServerOptions();
+        options.UserInteraction.ErrorIdParameter = null;
+
+        var app = BuildAppBuilder(identityServerOptions: options);
+
+        Action act = () => app.UseIdentityServer(CreateNoOpMiddlewareOptions());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("ErrorIdParameter is not configured");
+    }
+
+    [Fact]
+    public void UseIdentityServer_WithConsentUrlMissing_ShouldThrowInvalidOperationException()
+    {
+        var options = new IdentityServerOptions();
+        options.UserInteraction.ConsentUrl = null;
+
+        var app = BuildAppBuilder(identityServerOptions: options);
+
+        Action act = () => app.UseIdentityServer(CreateNoOpMiddlewareOptions());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("ConsentUrl is not configured");
+    }
+
+    [Fact]
+    public void UseIdentityServer_WithConsentReturnUrlParameterMissing_ShouldThrowInvalidOperationException()
+    {
+        var options = new IdentityServerOptions();
+        options.UserInteraction.ConsentReturnUrlParameter = null;
+
+        var app = BuildAppBuilder(identityServerOptions: options);
+
+        Action act = () => app.UseIdentityServer(CreateNoOpMiddlewareOptions());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("ConsentReturnUrlParameter is not configured");
+    }
+
+    [Fact]
+    public void UseIdentityServer_WithCustomRedirectReturnUrlParameterMissing_ShouldThrowInvalidOperationException()
+    {
+        var options = new IdentityServerOptions();
+        options.UserInteraction.CustomRedirectReturnUrlParameter = null;
+
+        var app = BuildAppBuilder(identityServerOptions: options);
+
+        Action act = () => app.UseIdentityServer(CreateNoOpMiddlewareOptions());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("CustomRedirectReturnUrlParameter is not configured");
+    }
+
+    [Fact]
+    public void UseIdentityServer_WithCheckSessionCookieNameMissing_ShouldThrowInvalidOperationException()
+    {
+        var options = new IdentityServerOptions();
+        options.Authentication.CheckSessionCookieName = null;
+
+        var app = BuildAppBuilder(identityServerOptions: options);
+
+        Action act = () => app.UseIdentityServer(CreateNoOpMiddlewareOptions());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("CheckSessionCookieName is not configured");
+    }
+
+    [Fact]
+    public void UseIdentityServer_WithCorsPolicyNameMissing_ShouldThrowInvalidOperationException()
+    {
+        var options = new IdentityServerOptions();
+        options.Cors.CorsPolicyName = null;
+
+        var app = BuildAppBuilder(identityServerOptions: options);
+
+        Action act = () => app.UseIdentityServer(CreateNoOpMiddlewareOptions());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("CorsPolicyName is not configured");
+    }
+
+    [Fact]
+    public void UseIdentityServer_WithCreateAccountUrlMissing_ShouldNotSupportPromptCreate()
+    {
+        var options = new IdentityServerOptions();
+        options.UserInteraction.CreateAccountUrl = null;
+
+        var app = BuildAppBuilder(identityServerOptions: options);
+
+        app.UseIdentityServer(CreateNoOpMiddlewareOptions());
+
+        options.UserInteraction.SupportedPromptModes.Should().NotContain(OidcConstants.PromptModes.Create);
+    }
+
+    [Fact]
+    public void UseIdentityServer_WithCreateAccountUrl_ShouldSupportPromptCreate()
+    {
+        var options = new IdentityServerOptions();
+        options.UserInteraction.CreateAccountUrl = "/account/create";
+
+        var app = BuildAppBuilder(identityServerOptions: options);
+
+        app.UseIdentityServer(CreateNoOpMiddlewareOptions());
+
+        options.UserInteraction.SupportedPromptModes.Should().Contain(OidcConstants.PromptModes.Create);
+    }
+
+    [Fact]
+    public void UseIdentityServer_WithCreateAccountUrlButCreateAccountReturnUrlParameterMissing_ShouldThrowInvalidOperationException()
+    {
+        var options = new IdentityServerOptions();
+        options.UserInteraction.CreateAccountUrl = "/account/create";
+        options.UserInteraction.CreateAccountReturnUrlParameter = null;
+
+        var app = BuildAppBuilder(identityServerOptions: options);
+
+        Action act = () => app.UseIdentityServer(CreateNoOpMiddlewareOptions());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("CreateAccountReturnUrlParameter is not configured");
+    }
+
+    private static IdentityServerMiddlewareOptions CreateNoOpMiddlewareOptions()
+        => new()
+        {
+            AuthenticationMiddleware = _ => { }
+        };
+
+    private static IApplicationBuilder BuildAppBuilder(
+        bool registerLoggerFactory = true,
+        bool registerPersistedGrantStore = true,
+        bool registerClientStore = true,
+        bool registerResourceStore = true,
+        IdentityServerOptions identityServerOptions = null)
+    {
+        var services = new ServiceCollection();
+
+        if (registerLoggerFactory)
+        {
+            services.AddSingleton<Microsoft.Extensions.Logging.ILoggerFactory, Microsoft.Extensions.Logging.LoggerFactory>();
+        }
+
+        services.AddAuthenticationCore();
+        services.AddCors();
+
+        services.AddSingleton(identityServerOptions ?? new IdentityServerOptions());
+
+        if (registerPersistedGrantStore)
+        {
+            services.AddSingleton(Mock.Of<IPersistedGrantStore>());
+        }
+
+        if (registerClientStore)
+        {
+            services.AddSingleton(Mock.Of<IClientStore>());
+        }
+
+        if (registerResourceStore)
+        {
+            services.AddSingleton(Mock.Of<IResourceStore>());
+        }
+
+        var serviceProvider = services.BuildServiceProvider();
+        return new ApplicationBuilder(serviceProvider);
+    }
+}

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Endpoints/Authorize/AuthorizeEndpointBaseTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Endpoints/Authorize/AuthorizeEndpointBaseTests.cs
@@ -142,6 +142,17 @@ public class AuthorizeEndpointBaseTests
 
     [Fact]
     [Trait("Category", Category)]
+    public async Task interaction_produces_create_result_should_trigger_create_account()
+    {
+        _stubInteractionGenerator.Response.IsCreateAccount = true;
+
+        var result = await _subject.ProcessAuthorizeRequestAsync(_params, _user, null);
+
+        result.Should().BeOfType<CreateAccountPageResult>();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
     public async Task ProcessAuthorizeRequestAsync_custom_interaction_redirect_result_should_issue_redirect()
     {
         _mockUserSession.User = _user;

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Endpoints/Results/CreateAccountPageResultTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Endpoints/Results/CreateAccountPageResultTests.cs
@@ -1,0 +1,97 @@
+﻿using AwesomeAssertions;
+using Moq;
+using Open.IdentityServer.Configuration;
+using Open.IdentityServer.Endpoints.Results;
+using Open.IdentityServer.Models;
+using Open.IdentityServer.Stores;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Open.IdentityServer.UnitTests.Endpoints.Results;
+
+public class CreateAccountPageResultTests : ReturnUrlResultTestBase<CreateAccountPageResult>
+{
+    protected override string ExpectedReturnUrlParameterName => Constants.UIConstants.DefaultRoutePathParams.CreateAccount;
+    protected override string ExpectedRedirectUrlPath => "/create-account";
+
+    protected override IdentityServerOptions CreateOptions() => new()
+    {
+        UserInteraction = new UserInteractionOptions
+        {
+            CreateAccountUrl = ExpectedRedirectUrlPath,
+            CreateAccountReturnUrlParameter = ExpectedReturnUrlParameterName
+        }
+    };
+
+    protected override CreateAccountPageResult CreateSut(IAuthorizationParametersMessageStore messageStore = null)
+        => new(TestAuthorizeRequest, Options, messageStore);
+
+    [Fact]
+    public async Task ExecuteAsync_WithLocalCreateAccountUrl_ShouldUseRelativeReturnUrl()
+    {
+        Options.UserInteraction.CreateAccountUrl = "/account/create";
+        var sut = CreateSut(messageStore: null);
+
+        await sut.ExecuteAsync(Context);
+
+        var urlDecoded = DecodeLocation();
+        urlDecoded.Should().StartWith("https://server/account/create");
+        urlDecoded.Should().NotContain($"{ExpectedReturnUrlParameterName}=https://server");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithExternalCreateAccountUrl_ShouldUseAbsoluteReturnUrl()
+    {
+        Options.UserInteraction.CreateAccountUrl = "https://external-login.com/account/create";
+        var sut = CreateSut(messageStore: null);
+
+        await sut.ExecuteAsync(Context);
+
+        var location = RawLocation();
+        location.Should().StartWith("https://external-login.com/account/create");
+        location.Should().Contain("https%3A%2F%2Fserver");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithExternalCreateAccountUrlAndMessageStore_ShouldUseAbsoluteReturnUrlWithMessageId()
+    {
+        var expectedId = "ext_msg_id";
+        Options.UserInteraction.CreateAccountUrl = "https://external-login.com/account/create";
+        Mock.Get(MessageStore)
+            .Setup(x => x.WriteAsync(It.IsAny<Message<IDictionary<string, string[]>>>()))
+            .ReturnsAsync(expectedId);
+
+        var sut = CreateSut(MessageStore);
+
+        await sut.ExecuteAsync(Context);
+
+        var location = RawLocation();
+        location.Should().StartWith("https://external-login.com/account/create");
+        location.Should().Contain("https%3A%2F%2Fserver");
+        location.Should().Contain(expectedId);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldUseConfiguredCreateAccountReturnUrlParameter()
+    {
+        Options.UserInteraction.CreateAccountReturnUrlParameter = "customReturnUrl";
+        var sut = CreateSut(messageStore: null);
+
+        await sut.ExecuteAsync(Context);
+
+        var urlDecoded = DecodeLocation();
+        urlDecoded.Should().Contain("customReturnUrl=");
+        urlDecoded.Should().NotContain($"{Constants.UIConstants.DefaultRoutePathParams.CreateAccount}=");
+    }
+
+    [Fact]
+    public void Constructor_WithNullRequest_ShouldThrowArgumentNullException()
+    {
+        var act = () => new CreateAccountPageResult(null);
+
+        act.Should().Throw<ArgumentNullException>()
+            .And.ParamName.Should().Be("request");
+    }
+}

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Endpoints/Results/CreateAccountPageResultTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Endpoints/Results/CreateAccountPageResultTests.cs
@@ -1,4 +1,7 @@
-﻿using AwesomeAssertions;
+﻿// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using AwesomeAssertions;
 using Moq;
 using Open.IdentityServer.Configuration;
 using Open.IdentityServer.Endpoints.Results;

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Consent.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Consent.cs
@@ -172,6 +172,24 @@ public class AuthorizeInteractionResponseGeneratorTests_Consent
         (await act.Should().ThrowAsync<ArgumentException>()).And.Message.Should().Contain("PromptMode");
     }
 
+    [Fact]
+    public async Task ProcessConsentAsync_PromptModeIsCreate_Throws()
+    {
+        RequiresConsent(true);
+        var request = new ValidatedAuthorizeRequest
+        {
+            ResponseMode = OidcConstants.ResponseModes.Fragment,
+            State = "12345",
+            RedirectUri = "https://client.com/callback",
+            PromptModes = [OidcConstants.PromptModes.Create],
+            RequestedScopes = ["openid", "read", "write"],
+            ValidatedResources = GetValidatedResources("openid", "read", "write"),
+        };
+
+        Func<Task> act = () => _subject.ProcessConsentAsync(request);
+
+        (await act.Should().ThrowAsync<ArgumentException>()).And.Message.Should().Contain("PromptMode");
+    }
 
     [Fact]
     public async Task ProcessConsentAsync_RequiresConsentButPromptModeIsNone_ReturnsErrorResult()

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Create.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Create.cs
@@ -1,4 +1,7 @@
-﻿using AwesomeAssertions;
+﻿// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using AwesomeAssertions;
 using Moq;
 using Open.IdentityServer.Services;
 using Open.IdentityServer.UnitTests.Common;

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Create.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Create.cs
@@ -1,0 +1,66 @@
+﻿using AwesomeAssertions;
+using Moq;
+using Open.IdentityServer.Services;
+using Open.IdentityServer.UnitTests.Common;
+using Open.IdentityServer.Validation;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Open.IdentityServer.UnitTests.ResponseHandling.AuthorizeInteractionResponseGenerator;
+
+public class AuthorizeInteractionResponseGeneratorTests_Create
+{
+    private readonly IdentityServer.ResponseHandling.AuthorizeInteractionResponseGenerator _subject;
+    private readonly MockConsentService _mockConsentService = new MockConsentService();
+    private readonly StubClock _clock = new StubClock();
+    private readonly Mock<ITelemetryService> _telemetry = new Mock<ITelemetryService>();
+
+    public AuthorizeInteractionResponseGeneratorTests_Create()
+    {
+        _subject = new IdentityServer.ResponseHandling.AuthorizeInteractionResponseGenerator(
+            _clock,
+            TestLogger.Create<IdentityServer.ResponseHandling.AuthorizeInteractionResponseGenerator>(),
+            _mockConsentService,
+            new MockProfileService(),
+            _telemetry.Object);
+    }
+
+    [Fact]
+    public async Task ProcessCreateAsync_PromptModeIsCreate_ReturnsCreateAccountResult()
+    {
+        var request = new ValidatedAuthorizeRequest
+        {
+            ResponseMode = OidcConstants.ResponseModes.Fragment,
+            State = "12345",
+            RedirectUri = "https://client.com/callback",
+            PromptModes = [OidcConstants.PromptModes.Create]
+        };
+
+        var result = await _subject.ProcessCreateAsync(request);
+        result.IsCreateAccount.Should().BeTrue();        
+    }
+
+    [Fact]
+    public async Task ProcessCreateAsync_PromptModeIsNotCreate_ReturnsEmptyResult()
+    {
+        var request = new ValidatedAuthorizeRequest
+        {
+            ResponseMode = OidcConstants.ResponseModes.Fragment,
+            State = "12345",
+            RedirectUri = "https://client.com/callback"
+        };
+
+        var result = await _subject.ProcessCreateAsync(request);
+        result.IsCreateAccount.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ProcessCreateAsync_WithNullRequest_ShouldThrowArgumentNullException()
+    {
+        var act = () => _subject.ProcessCreateAsync(null);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+}

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Login.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Login.cs
@@ -258,13 +258,13 @@ public class AuthorizeInteractionResponseGeneratorTests_Login
     }
 
     [Fact]
-    public async Task prompt_for_signin_should_remove_prompt_from_raw_url()
+    public async Task prompt_for_signin_should_not_remove_prompt_from_raw_url()
     {
         var request = new ValidatedAuthorizeRequest
         {
             ClientId = "foo",
             Subject = new IdentityServerUser("123").CreatePrincipal(),
-            PromptModes = new[] { OidcConstants.PromptModes.Login },
+            PromptModes = [OidcConstants.PromptModes.Login],
             Raw = new NameValueCollection
             {
                 { OidcConstants.AuthorizeRequest.Prompt, OidcConstants.PromptModes.Login }
@@ -273,6 +273,6 @@ public class AuthorizeInteractionResponseGeneratorTests_Login
 
         var result = await _subject.ProcessLoginAsync(request);
 
-        request.Raw.AllKeys.Should().NotContain(OidcConstants.AuthorizeRequest.Prompt);
+        request.Raw.AllKeys.Should().Contain(OidcConstants.AuthorizeRequest.Prompt);
     }
 }

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_Invalid.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_Invalid.cs
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Modified by Rock Solid Knowledge Ltd. Copyright in modifications 2026, Rock Solid Knowledge Ltd.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_Invalid.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_Invalid.cs
@@ -445,4 +445,46 @@ public class Authorize_ProtocolValidation_Invalid
         result.IsError.Should().BeTrue();
         result.Error.Should().Be(OidcConstants.AuthorizeErrors.InvalidRequest);
     }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task prompt_create_and_other_values_should_fail()
+    {
+        var parameters = new NameValueCollection
+        {
+            { OidcConstants.AuthorizeRequest.ClientId, "codeclient" },
+            { OidcConstants.AuthorizeRequest.Scope, "openid" },
+            { OidcConstants.AuthorizeRequest.RedirectUri, "https://server/cb" },
+            { OidcConstants.AuthorizeRequest.ResponseType, OidcConstants.ResponseTypes.Code },
+            { OidcConstants.AuthorizeRequest.ResponseMode, OidcConstants.ResponseModes.Fragment },
+            { OidcConstants.AuthorizeRequest.Prompt, "create login" }
+        };
+
+        var validator = Factory.CreateAuthorizeRequestValidator();
+        var result = await validator.ValidateAsync(parameters);
+
+        result.IsError.Should().BeTrue();
+        result.Error.Should().Be(OidcConstants.AuthorizeErrors.InvalidRequest);
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task prompt_unsupported_values_should_fail()
+    {
+        var parameters = new NameValueCollection
+        {
+            { OidcConstants.AuthorizeRequest.ClientId, "codeclient" },
+            { OidcConstants.AuthorizeRequest.Scope, "openid" },
+            { OidcConstants.AuthorizeRequest.RedirectUri, "https://server/cb" },
+            { OidcConstants.AuthorizeRequest.ResponseType, OidcConstants.ResponseTypes.Code },
+            { OidcConstants.AuthorizeRequest.ResponseMode, OidcConstants.ResponseModes.Fragment },
+            { OidcConstants.AuthorizeRequest.Prompt, "unsupported" }
+        };
+
+        var validator = Factory.CreateAuthorizeRequestValidator();
+        var result = await validator.ValidateAsync(parameters);
+
+        result.IsError.Should().BeTrue();
+        result.Error.Should().Be(OidcConstants.AuthorizeErrors.InvalidRequest);
+    }
 }

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_Valid.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_Valid.cs
@@ -217,7 +217,7 @@ public class Authorize_ProtocolValidation_Valid
             { OidcConstants.AuthorizeRequest.RedirectUri, "https://server/cb" },
             { OidcConstants.AuthorizeRequest.ResponseType, OidcConstants.ResponseTypes.Code },
             { OidcConstants.AuthorizeRequest.ResponseMode, OidcConstants.ResponseModes.Fragment },
-            { OidcConstants.AuthorizeRequest.Prompt, "login" },
+            { OidcConstants.AuthorizeRequest.Prompt, OidcConstants.PromptModes.Login },
             { Constants.ProcessedParameters.PromptProcessed, "true" }
         };
 
@@ -226,11 +226,12 @@ public class Authorize_ProtocolValidation_Valid
 
         result.IsError.Should().BeFalse();
         result.ValidatedRequest.PromptModes.Should().BeEmpty();
+        result.ValidatedRequest.ProcessedPromptModes.Should().Contain(OidcConstants.PromptModes.Login);
     }
 
     [Fact]
     [Trait("Category", Category)]
-    public async Task processed_max_age_should_not_be_processed_again()
+    public async Task processed_max_age_should_not_be_processed_again_when_zero()
     {
         var parameters = new NameValueCollection
         {
@@ -248,5 +249,27 @@ public class Authorize_ProtocolValidation_Valid
 
         result.IsError.Should().BeFalse();
         result.ValidatedRequest.MaxAge.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task processed_max_age_should_be_processed_again_when_not_zero()
+    {
+        var parameters = new NameValueCollection
+        {
+            { OidcConstants.AuthorizeRequest.ClientId, "codeclient" },
+            { OidcConstants.AuthorizeRequest.Scope, "openid" },
+            { OidcConstants.AuthorizeRequest.RedirectUri, "https://server/cb" },
+            { OidcConstants.AuthorizeRequest.ResponseType, OidcConstants.ResponseTypes.Code },
+            { OidcConstants.AuthorizeRequest.ResponseMode, OidcConstants.ResponseModes.Fragment },
+            { OidcConstants.AuthorizeRequest.MaxAge, "10" },
+            { Constants.ProcessedParameters.MaxAgeProcessed, "true" }
+        };
+
+        var validator = Factory.CreateAuthorizeRequestValidator();
+        var result = await validator.ValidateAsync(parameters);
+
+        result.IsError.Should().BeFalse();
+        result.ValidatedRequest.MaxAge.Should().Be(10);
     }
 }

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_Valid.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_Valid.cs
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Modified by Rock Solid Knowledge Ltd. Copyright in modifications 2026, Rock Solid Knowledge Ltd.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -203,5 +204,49 @@ public class Authorize_ProtocolValidation_Valid
         result.ValidatedRequest.PromptModes.Count().Should().Be(2);
         result.ValidatedRequest.PromptModes.Should().Contain(OidcConstants.PromptModes.Login);
         result.ValidatedRequest.PromptModes.Should().Contain(OidcConstants.PromptModes.Consent);
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task processed_prompt_values_should_not_be_processed_again()
+    {
+        var parameters = new NameValueCollection
+        {
+            { OidcConstants.AuthorizeRequest.ClientId, "codeclient" },
+            { OidcConstants.AuthorizeRequest.Scope, "openid" },
+            { OidcConstants.AuthorizeRequest.RedirectUri, "https://server/cb" },
+            { OidcConstants.AuthorizeRequest.ResponseType, OidcConstants.ResponseTypes.Code },
+            { OidcConstants.AuthorizeRequest.ResponseMode, OidcConstants.ResponseModes.Fragment },
+            { OidcConstants.AuthorizeRequest.Prompt, "login" },
+            { Constants.ProcessedParameters.PromptProcessed, "true" }
+        };
+
+        var validator = Factory.CreateAuthorizeRequestValidator();
+        var result = await validator.ValidateAsync(parameters);
+
+        result.IsError.Should().BeFalse();
+        result.ValidatedRequest.PromptModes.Should().BeEmpty();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task processed_max_age_should_not_be_processed_again()
+    {
+        var parameters = new NameValueCollection
+        {
+            { OidcConstants.AuthorizeRequest.ClientId, "codeclient" },
+            { OidcConstants.AuthorizeRequest.Scope, "openid" },
+            { OidcConstants.AuthorizeRequest.RedirectUri, "https://server/cb" },
+            { OidcConstants.AuthorizeRequest.ResponseType, OidcConstants.ResponseTypes.Code },
+            { OidcConstants.AuthorizeRequest.ResponseMode, OidcConstants.ResponseModes.Fragment },
+            { OidcConstants.AuthorizeRequest.MaxAge, "0" },
+            { Constants.ProcessedParameters.MaxAgeProcessed, "true" }
+        };
+
+        var validator = Factory.CreateAuthorizeRequestValidator();
+        var result = await validator.ValidateAsync(parameters);
+
+        result.IsError.Should().BeFalse();
+        result.ValidatedRequest.MaxAge.Should().BeNull();
     }
 }


### PR DESCRIPTION
## Description

Improvments of prompt and max_age parameter handling.

## Type of change

[ ] Bug fix
[x] Feature
[ ] Refactoring
[ ] Documentation
[ ] Other

Implementation of feature #54.

## Does this PR introduce a breaking change?

[x] Yes
[ ] No

The old code ignored unsupported prompt modes, but this implementation returns an error to the client.

## Testing

I have fixed an error in an existing integration test.
There are several new integration tests.

## LLM Usage

I have not used LLM, except for the extended auto-complete feature primarly used for XML comments.
I used co-pilot to set up some structure for the IdentityServerApplicationBuilderExtensionsTests class.

## Other context

I believe this implementation is better aligned with current Duende IdentityServer implementation, but it is a breaking change compared to IdSrv 4 code base which ignored unsupported prompt values.