### PR TITLE
feat: implement client lifetime updates on session events

### DIFF
--- a/src/EntityFramework.Storage/src/Entities/Client.cs
+++ b/src/EntityFramework.Storage/src/Entities/Client.cs
@@ -65,11 +65,11 @@ public class Client
     public string UserCodeType { get; set; }
     public int DeviceCodeLifetime { get; set; } = 300;
     public bool NonEditable { get; set; }
+    public bool? CoordinateLifetimeWithUserSession { get; set; }
     
     //Unused Compatibility Properties
     public int? CibaLifetime { get; set; }
     public int? PollingInterval { get; set; }
-    public bool? CoordinateLifetimeWithUserSession { get; set; }
     public string InitiateLoginUri { get; set; }
     public TimeSpan DPoPClockSkew { get; set; }
     public int DPoPValidationMode { get; set; }

--- a/src/EntityFramework.Storage/src/Stores/PersistedGrantStore.cs
+++ b/src/EntityFramework.Storage/src/Stores/PersistedGrantStore.cs
@@ -172,37 +172,41 @@ public class PersistedGrantStore : IPersistedGrantStore
     {
         if (trace == null) return;
 
-        if (!String.IsNullOrWhiteSpace(filter.ClientId))
+        var clientIds = filter.ClientIds.Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
+        if (clientIds.Any())
         {
-            trace.AddTag(TelemetryConstants.TagConstants.Client, filter.ClientId);
+            trace.AddTag(TelemetryConstants.TagConstants.Client, string.Join(",", filter.ClientIds));
         }
-        if (!String.IsNullOrWhiteSpace(filter.SubjectId))
+        if (!string.IsNullOrWhiteSpace(filter.SubjectId))
         {
             trace.AddTag(TelemetryConstants.TagConstants.Subject, filter.SubjectId);
         }
-        if (!String.IsNullOrWhiteSpace(filter.Type))
+        var types = filter.Types.Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
+        if (types.Any())
         {
-            trace.AddTag(TelemetryConstants.TagConstants.GrantType, filter.Type);
+            trace.AddTag(TelemetryConstants.TagConstants.GrantType, string.Join(",", filter.Types));
         }
     }
 
     private IQueryable<Entities.PersistedGrant> Filter(IQueryable<Entities.PersistedGrant> query, PersistedGrantFilter filter)
     {
-        if (!String.IsNullOrWhiteSpace(filter.ClientId))
+        var clientIds = filter.ClientIds.Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
+        if (clientIds.Any())
         {
-            query = query.Where(x => x.ClientId == filter.ClientId);
+            query = query.Where(x => clientIds.Contains(x.ClientId));
         }
-        if (!String.IsNullOrWhiteSpace(filter.SessionId))
+        if (!string.IsNullOrWhiteSpace(filter.SessionId))
         {
             query = query.Where(x => x.SessionId == filter.SessionId);
         }
-        if (!String.IsNullOrWhiteSpace(filter.SubjectId))
+        if (!string.IsNullOrWhiteSpace(filter.SubjectId))
         {
             query = query.Where(x => x.SubjectId == filter.SubjectId);
         }
-        if (!String.IsNullOrWhiteSpace(filter.Type))
+        var types = filter.Types.Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
+        if (types.Any())
         {
-            query = query.Where(x => x.Type == filter.Type);
+            query = query.Where(x => types.Contains(x.Type));
         }
 
         return query;

--- a/src/EntityFramework.Storage/src/Stores/PersistedGrantStore.cs
+++ b/src/EntityFramework.Storage/src/Stores/PersistedGrantStore.cs
@@ -101,7 +101,6 @@ public class PersistedGrantStore : IPersistedGrantStore
     public async Task<IEnumerable<PersistedGrant>> GetAllAsync(PersistedGrantFilter filter)
     {
         using var trace = Telemetry.Trace(TelemetryConstants.TraceCategories.Stores, this);
-        AddFilterTags(trace, filter);
         
         filter.Validate();
 
@@ -147,7 +146,6 @@ public class PersistedGrantStore : IPersistedGrantStore
     public async Task RemoveAllAsync(PersistedGrantFilter filter)
     {
         using var trace = Telemetry.Trace(TelemetryConstants.TraceCategories.Stores, this);
-        AddFilterTags(trace, filter);
         
         filter.Validate();
 
@@ -165,26 +163,6 @@ public class PersistedGrantStore : IPersistedGrantStore
         catch (DbUpdateConcurrencyException ex)
         {
             Logger.LogInformation("removing {persistedGrantCount} persisted grants from database for subject {@filter}: {error}", persistedGrants.Length, filter, ex.Message);
-        }
-    }
-
-    private void AddFilterTags(ITrace trace, PersistedGrantFilter filter)
-    {
-        if (trace == null) return;
-
-        var clientIds = filter.ClientIds.Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
-        if (clientIds.Any())
-        {
-            trace.AddTag(TelemetryConstants.TagConstants.Client, string.Join(",", filter.ClientIds));
-        }
-        if (!string.IsNullOrWhiteSpace(filter.SubjectId))
-        {
-            trace.AddTag(TelemetryConstants.TagConstants.Subject, filter.SubjectId);
-        }
-        var types = filter.Types.Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
-        if (types.Any())
-        {
-            trace.AddTag(TelemetryConstants.TagConstants.GrantType, string.Join(",", filter.Types));
         }
     }
 

--- a/src/EntityFramework.Storage/test/IntegrationTests/Stores/PersistedGrantStoreTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/Stores/PersistedGrantStoreTests.cs
@@ -187,6 +187,19 @@ public class PersistedGrantStoreTests : IntegrationTest<PersistedGrantStoreTests
                 SessionId = "s1",
                 Type = "t3"
             })).ToList().Count.Should().Be(0);
+            (await store.GetAllAsync(new PersistedGrantFilter
+            {
+                ClientIds = ["c1", "c3"],
+            })).ToList().Count.Should().Be(5);
+            (await store.GetAllAsync(new PersistedGrantFilter
+            {
+                Types = ["t2", "t3"],
+            })).ToList().Count.Should().Be(5);
+            (await store.GetAllAsync(new PersistedGrantFilter
+            {
+                ClientIds = ["c1", "c2"],
+                Types = ["t1", "t2"],
+            })).ToList().Count.Should().Be(8);
         }
     }
 
@@ -333,8 +346,7 @@ public class PersistedGrantStoreTests : IntegrationTest<PersistedGrantStoreTests
             });
             context.PersistedGrants.Count().Should().Be(9);
         }
-
-
+        
         await PopulateDb();
         await using (var context = new PersistedGrantDbContext(options, StoreOptions))
         {
@@ -404,6 +416,43 @@ public class PersistedGrantStoreTests : IntegrationTest<PersistedGrantStoreTests
                 Type = "t3"
             });
             context.PersistedGrants.Count().Should().Be(10);
+        }
+
+        await PopulateDb();
+        await using (var context = new PersistedGrantDbContext(options, StoreOptions))
+        {
+            var store = new PersistedGrantStore(context, _telemetry,  FakeLogger<PersistedGrantStore>.Create());
+
+            await store.RemoveAllAsync(new PersistedGrantFilter
+            {
+                ClientIds = ["c2", "c3"],
+            });
+            context.PersistedGrants.Count().Should().Be(5);
+        }
+
+        await PopulateDb();
+        await using (var context = new PersistedGrantDbContext(options, StoreOptions))
+        {
+            var store = new PersistedGrantStore(context, _telemetry,  FakeLogger<PersistedGrantStore>.Create());
+
+            await store.RemoveAllAsync(new PersistedGrantFilter
+            {
+                Types = ["t1", "t2"],
+            });
+            context.PersistedGrants.Count().Should().Be(2);
+        }
+
+        await PopulateDb();
+        await using (var context = new PersistedGrantDbContext(options, StoreOptions))
+        {
+            var store = new PersistedGrantStore(context, _telemetry,  FakeLogger<PersistedGrantStore>.Create());
+
+            await store.RemoveAllAsync(new PersistedGrantFilter
+            {
+                ClientIds = ["c1", "c3"],
+                Types = ["t2", "t3"],
+            });
+            context.PersistedGrants.Count().Should().Be(7);
         }
 
         return;

--- a/src/Open.IdentityServer/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
+++ b/src/Open.IdentityServer/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
@@ -16,6 +16,7 @@ using Open.IdentityServer.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Open.IdentityServer.Models;
+using Open.IdentityServer.Services.Default;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -473,6 +474,7 @@ public static class IdentityServerBuilderExtensionsAdditional
     {
         builder.Services.AddSingleton<IPostConfigureOptions<CookieAuthenticationOptions>, PostConfigureSessionStoreCookieAuthOptions>();
         builder.Services.AddScoped<ITicketStore, ServerSessionTicketStore>();
+        builder.Services.AddScoped<IUserSessionEventsService, DefaultUserSessionEventsService>();
         
         // provide default in-memory implementation, not suitable for most production scenarios (following pattern implemented with existing stores)
         builder.Services.TryAddSingleton<IIdentityServerServerSideSessionStore, InMemorySessionStore>();

--- a/src/Open.IdentityServer/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
+++ b/src/Open.IdentityServer/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
@@ -474,7 +474,7 @@ public static class IdentityServerBuilderExtensionsAdditional
     {
         builder.Services.AddSingleton<IPostConfigureOptions<CookieAuthenticationOptions>, PostConfigureSessionStoreCookieAuthOptions>();
         builder.Services.AddScoped<ITicketStore, ServerSessionTicketStore>();
-        builder.Services.AddScoped<IUserSessionEventsService, DefaultUserSessionEventsService>();
+        // builder.Services.AddScoped<IUserSessionEventsService, DefaultUserSessionEventsService>();
         
         // provide default in-memory implementation, not suitable for most production scenarios (following pattern implemented with existing stores)
         builder.Services.TryAddSingleton<IIdentityServerServerSideSessionStore, InMemorySessionStore>();

--- a/src/Open.IdentityServer/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
+++ b/src/Open.IdentityServer/src/Configuration/DependencyInjection/BuilderExtensions/Additional.cs
@@ -474,7 +474,6 @@ public static class IdentityServerBuilderExtensionsAdditional
     {
         builder.Services.AddSingleton<IPostConfigureOptions<CookieAuthenticationOptions>, PostConfigureSessionStoreCookieAuthOptions>();
         builder.Services.AddScoped<ITicketStore, ServerSessionTicketStore>();
-        // builder.Services.AddScoped<IUserSessionEventsService, DefaultUserSessionEventsService>();
         
         // provide default in-memory implementation, not suitable for most production scenarios (following pattern implemented with existing stores)
         builder.Services.TryAddSingleton<IIdentityServerServerSideSessionStore, InMemorySessionStore>();

--- a/src/Open.IdentityServer/src/Configuration/DependencyInjection/BuilderExtensions/Core.cs
+++ b/src/Open.IdentityServer/src/Configuration/DependencyInjection/BuilderExtensions/Core.cs
@@ -136,6 +136,8 @@ public static class IdentityServerBuilderExtensionsCore
 
         builder.Services.AddCors();
         builder.Services.AddTransientDecorator<ICorsPolicyProvider, CorsPolicyProvider>();
+        
+        builder.Services.AddScoped<IUserSessionEventsService, DefaultUserSessionEventsService>();
 
         return builder;
     }

--- a/src/Open.IdentityServer/src/Configuration/DependencyInjection/Options/AuthenticationOptions.cs
+++ b/src/Open.IdentityServer/src/Configuration/DependencyInjection/Options/AuthenticationOptions.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Modified by Rock Solid Knowledge Ltd. Copyright in modifications 2026, Rock Solid Knowledge Ltd.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
-
 
 using System;
 using Microsoft.AspNetCore.Http;
@@ -60,4 +60,10 @@ public class AuthenticationOptions
     /// If set, will require frame-src CSP headers being emitting on the end session callback endpoint which renders iframes to clients for front-channel signout notification.
     /// </summary>
     public bool RequireCspFrameSrcForSignout { get; set; } = true;
+    
+    /// <summary>
+    /// If set, refresh token lifetimes will be tied to the users' session. This setting can be overridden at a client
+    /// level. 
+    /// </summary>
+    public bool CoordinateClientLifetimesWithUserSession { get; set; }
 }

--- a/src/Open.IdentityServer/src/Configuration/DependencyInjection/Options/AuthenticationOptions.cs
+++ b/src/Open.IdentityServer/src/Configuration/DependencyInjection/Options/AuthenticationOptions.cs
@@ -62,7 +62,7 @@ public class AuthenticationOptions
     public bool RequireCspFrameSrcForSignout { get; set; } = true;
     
     /// <summary>
-    /// If set, refresh token lifetimes will be tied to the users' session. This setting can be overridden at a client
+    /// If set, refresh token lifetimes will be tied to the users' session. This setting can be overridden at the client
     /// level. 
     /// </summary>
     public bool CoordinateClientLifetimesWithUserSession { get; set; }

--- a/src/Open.IdentityServer/src/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
+++ b/src/Open.IdentityServer/src/Configuration/DependencyInjection/Options/IdentityServerOptions.cs
@@ -2,7 +2,6 @@
 // Modified by Rock Solid Knowledge Ltd. Copyright in modifications 2026, Rock Solid Knowledge Ltd.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-
 namespace Open.IdentityServer.Configuration;
 
 /// <summary>
@@ -54,7 +53,7 @@ public class IdentityServerOptions
     /// <value>
     /// The endpoints configuration.
     /// </value>
-    public EndpointsOptions Endpoints { get; set; } = new EndpointsOptions();
+    public EndpointsOptions Endpoints { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the discovery endpoint configuration.
@@ -62,7 +61,7 @@ public class IdentityServerOptions
     /// <value>
     /// The discovery endpoint configuration.
     /// </value>
-    public DiscoveryOptions Discovery { get; set; } = new DiscoveryOptions();
+    public DiscoveryOptions Discovery { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the authentication options.
@@ -70,7 +69,7 @@ public class IdentityServerOptions
     /// <value>
     /// The authentication options.
     /// </value>
-    public AuthenticationOptions Authentication { get; set; } = new AuthenticationOptions();
+    public AuthenticationOptions Authentication { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the events options.
@@ -78,7 +77,7 @@ public class IdentityServerOptions
     /// <value>
     /// The events options.
     /// </value>
-    public EventsOptions Events { get; set; } = new EventsOptions();
+    public EventsOptions Events { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the max input length restrictions.
@@ -86,7 +85,7 @@ public class IdentityServerOptions
     /// <value>
     /// The length restrictions.
     /// </value>
-    public InputLengthRestrictions InputLengthRestrictions { get; set; } = new InputLengthRestrictions();
+    public InputLengthRestrictions InputLengthRestrictions { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the options for the user interaction.
@@ -94,7 +93,7 @@ public class IdentityServerOptions
     /// <value>
     /// The user interaction options.
     /// </value>
-    public UserInteractionOptions UserInteraction { get; set; } = new UserInteractionOptions();
+    public UserInteractionOptions UserInteraction { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the caching options.
@@ -102,7 +101,7 @@ public class IdentityServerOptions
     /// <value>
     /// The caching options.
     /// </value>
-    public CachingOptions Caching { get; set; } = new CachingOptions();
+    public CachingOptions Caching { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the cors options.
@@ -110,35 +109,40 @@ public class IdentityServerOptions
     /// <value>
     /// The cors options.
     /// </value>
-    public CorsOptions Cors { get; set; } = new CorsOptions();
+    public CorsOptions Cors { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the Content Security Policy options.
     /// </summary>
-    public CspOptions Csp { get; set; } = new CspOptions();
+    public CspOptions Csp { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the validation options.
     /// </summary>
-    public ValidationOptions Validation { get; set; } = new ValidationOptions();
+    public ValidationOptions Validation { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the device flow options.
     /// </summary>
-    public DeviceFlowOptions DeviceFlow { get; set; } = new DeviceFlowOptions();
+    public DeviceFlowOptions DeviceFlow { get; set; } = new();
         
     /// <summary>
     /// Gets or sets the logging options
     /// </summary>
-    public LoggingOptions Logging { get; set; } = new LoggingOptions();
+    public LoggingOptions Logging { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the mutual TLS options.
     /// </summary>
-    public MutualTlsOptions MutualTls { get; set; } = new MutualTlsOptions();
+    public MutualTlsOptions MutualTls { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the enable authorise response issuer param option
     /// </summary>
     public bool EnableAuthorizeResponseIssuerParam { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets the server-side session options
+    /// </summary>
+    public ServerSideSessionsOptions ServerSideSessions { get; set; } = new();
 }

--- a/src/Open.IdentityServer/src/Configuration/DependencyInjection/Options/ServerSideSessionsOptions.cs
+++ b/src/Open.IdentityServer/src/Configuration/DependencyInjection/Options/ServerSideSessionsOptions.cs
@@ -4,12 +4,14 @@
 namespace Open.IdentityServer.Configuration;
 
 /// <summary>
-/// 
+/// Server side sessions options.
 /// </summary>
 public class ServerSideSessionsOptions
 {
     /// <summary>
-    /// 
+    /// Specifies if session expiry should trigger back channel logout, this will override any other settings that may
+    /// cause back channel logout such as AuthenticationOptions.CoordinateClientLifetimesWithUserSession or
+    /// Client.CoordinateLifetimeWithUserSession.
     /// </summary>
     public bool ExpiredSessionsTriggerBackchannelLogout { get; set; }
 }

--- a/src/Open.IdentityServer/src/Configuration/DependencyInjection/Options/ServerSideSessionsOptions.cs
+++ b/src/Open.IdentityServer/src/Configuration/DependencyInjection/Options/ServerSideSessionsOptions.cs
@@ -3,7 +3,13 @@
 
 namespace Open.IdentityServer.Configuration;
 
+/// <summary>
+/// 
+/// </summary>
 public class ServerSideSessionsOptions
 {
+    /// <summary>
+    /// 
+    /// </summary>
     public bool ExpiredSessionsTriggerBackchannelLogout { get; set; }
 }

--- a/src/Open.IdentityServer/src/Configuration/DependencyInjection/Options/ServerSideSessionsOptions.cs
+++ b/src/Open.IdentityServer/src/Configuration/DependencyInjection/Options/ServerSideSessionsOptions.cs
@@ -1,0 +1,9 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace Open.IdentityServer.Configuration;
+
+public class ServerSideSessionsOptions
+{
+    public bool ExpiredSessionsTriggerBackchannelLogout { get; set; }
+}

--- a/src/Open.IdentityServer/src/Hosting/IdentityServerMiddleware.cs
+++ b/src/Open.IdentityServer/src/Hosting/IdentityServerMiddleware.cs
@@ -2,7 +2,6 @@
 // Modified by Rock Solid Knowledge Ltd. Copyright in modifications 2026, Rock Solid Knowledge Ltd.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-
 using Open.IdentityServer.Events;
 using Open.IdentityServer.Extensions;
 using Open.IdentityServer.Services;
@@ -70,6 +69,12 @@ public class IdentityServerMiddleware
                 // notify other services of logout when required
                 var user = await session.GetUserAsync();
                 var clientIds = await session.GetClientListAsync();
+
+                if (user == null)
+                {
+                    return;
+                }
+                
                 await userSessionEventsService.HandleUserSessionLogout(new UserSessionEventContext
                 {
                     SessionId = await session.GetSessionIdAsync(),

--- a/src/Open.IdentityServer/src/Hosting/IdentityServerMiddleware.cs
+++ b/src/Open.IdentityServer/src/Hosting/IdentityServerMiddleware.cs
@@ -9,7 +9,9 @@ using Open.IdentityServer.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Linq;
 using System.Threading.Tasks;
+using Open.IdentityServer.Models;
 
 namespace Open.IdentityServer.Hosting;
 
@@ -40,6 +42,7 @@ public class IdentityServerMiddleware
     /// <param name="session">The user session.</param>
     /// <param name="events">The event service.</param>
     /// <param name="backChannelLogoutService">The service used to send back-channel logout notifications to clients when the user signs out.</param>
+    /// <param name="userSessionEventsService">The service for handling user session events</param>
     /// <param name="telemetryService">The telemetry service</param>
     /// <returns>A task that completes when the request has been handled by an IdentityServer endpoint or passed to the next middleware in the pipeline.</returns>
     public async Task Invoke(
@@ -47,7 +50,8 @@ public class IdentityServerMiddleware
         IEndpointRouter router, 
         IUserSession session, 
         IEventService events, 
-        IBackChannelLogoutService backChannelLogoutService, 
+        IBackChannelLogoutService backChannelLogoutService,
+        IUserSessionEventsService userSessionEventsService,
         ITelemetryService telemetryService)
     {
         // this will check the authentication session and from it emit the check session
@@ -62,13 +66,16 @@ public class IdentityServerMiddleware
 
                 // this clears our session id cookie so JS clients can detect the user has signed out
                 await session.RemoveSessionIdCookieAsync();
-
-                // back channel logout
-                var logoutContext = await session.GetLogoutNotificationContext();
-                if (logoutContext != null)
+                
+                // notify other services of logout when required
+                var user = await session.GetUserAsync();
+                var clientIds = await session.GetClientListAsync();
+                await userSessionEventsService.HandleUserSessionLogout(new UserSessionEventContext
                 {
-                    await backChannelLogoutService.SendLogoutNotificationsAsync(logoutContext);
-                }
+                    SessionId = await session.GetSessionIdAsync(),
+                    SubjectId = user.GetSubjectId(),
+                    ClientIds = clientIds.ToArray(),
+                });
             }
         });
 

--- a/src/Open.IdentityServer/src/IdentityServerConstants.cs
+++ b/src/Open.IdentityServer/src/IdentityServerConstants.cs
@@ -152,6 +152,8 @@ public static class IdentityServerConstants
         public const string UserConsent = "user_consent";
         public const string DeviceCode = "device_code";
         public const string UserCode = "user_code";
+
+        public static readonly string[] PersistedGrantTokenTypes = [AuthorizationCode, ReferenceToken, RefreshToken];
     }
 
     public static class UserCodeTypes

--- a/src/Open.IdentityServer/src/Models/Contexts/UserSessionEventContext.cs
+++ b/src/Open.IdentityServer/src/Models/Contexts/UserSessionEventContext.cs
@@ -4,22 +4,22 @@
 namespace Open.IdentityServer.Models;
 
 /// <summary>
-/// Provides the context necessary to handle user session events
+/// Provides the context for handling user session events
 /// </summary>
 public class UserSessionEventContext
 {
     /// <summary>
-    /// Subject identifier of the user of the session the event has been triggered for
+    /// Subject identifier of the User of the session for which the event has been triggered.
     /// </summary>
     public string SubjectId { get; set; }
     
     /// <summary>
-    /// Session identifier of the session the event has been triggered for
+    /// Session identifier for the event that has been triggered.
     /// </summary>
     public string SessionId { get; set; }
 
     /// <summary>
-    /// ClientIds logged into with the user session
+    /// Collection of ClientId active within the session.
     /// </summary>
     public string[] ClientIds { get; set; } = [];
 }

--- a/src/Open.IdentityServer/src/Models/Contexts/UserSessionEventContext.cs
+++ b/src/Open.IdentityServer/src/Models/Contexts/UserSessionEventContext.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace Open.IdentityServer.Models;
+
+/// <summary>
+/// Provides the context necessary to handle user session events
+/// </summary>
+public class UserSessionEventContext
+{
+    /// <summary>
+    /// Subject identifier of the user of the session the event has been triggered for
+    /// </summary>
+    public string SubjectId { get; set; }
+    
+    /// <summary>
+    /// Session identifier of the session the event has been triggered for
+    /// </summary>
+    public string SessionId { get; set; }
+    
+    /// <summary>
+    /// ClientIds logged into with the user session
+    /// </summary>
+    public string[] ClientIds { get; set; }
+}

--- a/src/Open.IdentityServer/src/Models/Contexts/UserSessionEventContext.cs
+++ b/src/Open.IdentityServer/src/Models/Contexts/UserSessionEventContext.cs
@@ -17,9 +17,9 @@ public class UserSessionEventContext
     /// Session identifier of the session the event has been triggered for
     /// </summary>
     public string SessionId { get; set; }
-    
+
     /// <summary>
     /// ClientIds logged into with the user session
     /// </summary>
-    public string[] ClientIds { get; set; }
+    public string[] ClientIds { get; set; } = [];
 }

--- a/src/Open.IdentityServer/src/Services/Default/DefaultUserSessionEventsService.cs
+++ b/src/Open.IdentityServer/src/Services/Default/DefaultUserSessionEventsService.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -20,19 +21,27 @@ namespace Open.IdentityServer.Services.Default;
 /// <param name="persistedGrantStore">persisted grant store</param>
 /// <param name="backChannelLogoutService">back channel logout service</param>
 /// <param name="idsOptions">IdentityServer options</param>
+/// <param name="telemetry">telemetry service</param>
 /// <param name="logger">logger</param>
 public class DefaultUserSessionEventsService(
     IClientStore clientStore,
     IPersistedGrantStore persistedGrantStore,
     IBackChannelLogoutService backChannelLogoutService,
     IdentityServerOptions idsOptions,
+    ITelemetryService telemetry,
     ILogger<DefaultUserSessionEventsService> logger) : IUserSessionEventsService
 {
     /// <inheritdoc />
     public async Task HandleUserSessionLogout(UserSessionEventContext sessionEventContext)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionEventContext.SessionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionEventContext.SubjectId);
+        
+        using var trace = telemetry.Trace(TelemetryConstants.TraceCategories.Services, this);
+        
         if (sessionEventContext.ClientIds.Length == 0)
         {
+            logger.LogInformation("no clients linked to session, nothing to be done");
             return;
         }
         
@@ -49,6 +58,11 @@ public class DefaultUserSessionEventsService(
     /// <inheritdoc />
     public async Task HandleUserSessionExpiry(UserSessionEventContext sessionEventContext)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionEventContext.SessionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionEventContext.SubjectId);
+        
+        using var trace = telemetry.Trace(TelemetryConstants.TraceCategories.Services, this);
+        
         var clientToNotify = await EndSessionForClients(sessionEventContext);
 
         var backChannelClients = (idsOptions.ServerSideSessions.ExpiredSessionsTriggerBackchannelLogout
@@ -57,6 +71,7 @@ public class DefaultUserSessionEventsService(
 
         if (backChannelClients.Count == 0)
         {
+            logger.LogInformation("no backchannel clients to notify");
             return;
         }
         
@@ -74,6 +89,7 @@ public class DefaultUserSessionEventsService(
 
         if (clientIds.Length == 0)
         {
+            logger.LogInformation("no clients to remove grants for");
             return null;
         }
 
@@ -88,16 +104,14 @@ public class DefaultUserSessionEventsService(
         return clientIds;
     }
 
-    private bool ShouldCoordinate(Client client) => client.CoordinateLifetimeWithUserSession ??
-                                                     idsOptions.Authentication.CoordinateClientLifetimesWithUserSession;
-
     private async IAsyncEnumerable<string> ClientIdsToCoordinate(UserSessionEventContext sessionEventContext)
     {
-        foreach (string clientId in sessionEventContext.ClientIds)
+        foreach (string clientId in sessionEventContext.ClientIds ?? [])
         {
             var client = await clientStore.FindClientByIdAsync(clientId);
 
-            if (client != null && ShouldCoordinate(client))
+            if (client != null && (client.CoordinateLifetimeWithUserSession ??
+                                   idsOptions.Authentication.CoordinateClientLifetimesWithUserSession))
             {
                 yield return client.ClientId;
             }

--- a/src/Open.IdentityServer/src/Services/Default/DefaultUserSessionEventsService.cs
+++ b/src/Open.IdentityServer/src/Services/Default/DefaultUserSessionEventsService.cs
@@ -1,0 +1,106 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Open.IdentityServer.Configuration;
+using Open.IdentityServer.Models;
+using Open.IdentityServer.Stores;
+
+namespace Open.IdentityServer.Services.Default;
+
+/// <summary>
+/// Default user session event handler for Open.IdentityServer
+/// </summary>
+/// <param name="clientStore">client store</param>
+/// <param name="persistedGrantStore">persisted grant store</param>
+/// <param name="backChannelLogoutService">back channel logout service</param>
+/// <param name="idsOptions">IdentityServer options</param>
+/// <param name="logger">logger</param>
+public class DefaultUserSessionEventsService(
+    IClientStore clientStore,
+    IPersistedGrantStore persistedGrantStore,
+    IBackChannelLogoutService backChannelLogoutService,
+    IdentityServerOptions idsOptions,
+    ILogger<DefaultUserSessionEventsService> logger) : IUserSessionEventsService
+{
+    /// <inheritdoc />
+    public async Task HandleUserSessionLogout(UserSessionEventContext sessionEventContext)
+    {
+        if (sessionEventContext.ClientIds.Length == 0)
+        {
+            return;
+        }
+        
+        await EndSessionForClients(sessionEventContext);
+        
+        await backChannelLogoutService.SendLogoutNotificationsAsync(new LogoutNotificationContext
+        {
+            SubjectId = sessionEventContext.SubjectId,
+            SessionId = sessionEventContext.SessionId,
+            ClientIds = sessionEventContext.ClientIds,
+        });
+    }
+
+    /// <inheritdoc />
+    public async Task HandleUserSessionExpiry(UserSessionEventContext sessionEventContext)
+    {
+        var clientToNotify = await EndSessionForClients(sessionEventContext);
+
+        var backChannelClients = (idsOptions.ServerSideSessions.ExpiredSessionsTriggerBackchannelLogout
+            ? sessionEventContext.ClientIds
+            : clientToNotify ?? []).ToList();
+
+        if (backChannelClients.Count == 0)
+        {
+            return;
+        }
+        
+        await backChannelLogoutService.SendLogoutNotificationsAsync(new LogoutNotificationContext
+        {
+            SubjectId = sessionEventContext.SubjectId,
+            SessionId = sessionEventContext.SessionId,
+            ClientIds = backChannelClients,
+        });
+    }
+
+    private async Task<string[]?> EndSessionForClients(UserSessionEventContext sessionEventContext)
+    {
+        var clientIds = await ClientIdsToCoordinate(sessionEventContext).ToArrayAsync();
+
+        if (clientIds.Length == 0)
+        {
+            return null;
+        }
+
+        await persistedGrantStore.RemoveAllAsync(new PersistedGrantFilter
+        {
+            SubjectId = sessionEventContext.SubjectId,
+            SessionId = sessionEventContext.SessionId,
+            ClientIds = sessionEventContext.ClientIds,
+            Types = IdentityServerConstants.PersistedGrantTypes.PersistedGrantTokenTypes
+        });
+
+        return clientIds;
+    }
+
+    private bool ShouldCoordinate(Client client) => client.CoordinateLifetimeWithUserSession ??
+                                                     idsOptions.Authentication.CoordinateClientLifetimesWithUserSession;
+
+    private async IAsyncEnumerable<string> ClientIdsToCoordinate(UserSessionEventContext sessionEventContext)
+    {
+        foreach (string clientId in sessionEventContext.ClientIds)
+        {
+            var client = await clientStore.FindClientByIdAsync(clientId);
+
+            if (client != null && ShouldCoordinate(client))
+            {
+                yield return client.ClientId;
+            }
+        }
+    }
+}

--- a/src/Open.IdentityServer/src/Services/IUserSessionEventsService.cs
+++ b/src/Open.IdentityServer/src/Services/IUserSessionEventsService.cs
@@ -1,0 +1,29 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+#nullable enable
+
+using System.Threading.Tasks;
+using Open.IdentityServer.Models;
+
+namespace Open.IdentityServer.Services;
+
+/// <summary>
+/// Service responsible handling user session events
+/// </summary>
+public interface IUserSessionEventsService
+{
+    /// <summary>
+    /// Triggered when session logout occurs
+    /// </summary>
+    /// <param name="sessionEventContext">context needed for handling logout event</param>
+    /// <returns></returns>
+    public Task HandleUserSessionLogout(UserSessionEventContext sessionEventContext);
+    
+    /// <summary>
+    /// Triggered when session expires
+    /// </summary>
+    /// <param name="sessionEventContext">context needed for handling logout event</param>
+    /// <returns></returns>
+    public Task HandleUserSessionExpiry(UserSessionEventContext sessionEventContext);
+}

--- a/src/Open.IdentityServer/src/Stores/InMemory/InMemoryPersistedGrantStore.cs
+++ b/src/Open.IdentityServer/src/Stores/InMemory/InMemoryPersistedGrantStore.cs
@@ -77,21 +77,23 @@ public class InMemoryPersistedGrantStore : IPersistedGrantStore
             from item in _repository
             select item.Value;
 
-        if (!String.IsNullOrWhiteSpace(filter.ClientId))
+        var clientIds = filter.ClientIds.Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
+        if (clientIds.Any())
         {
-            query = query.Where(x => x.ClientId == filter.ClientId);
+            query = query.Where(x => clientIds.Contains(x.ClientId));
         }
-        if (!String.IsNullOrWhiteSpace(filter.SessionId))
+        if (!string.IsNullOrWhiteSpace(filter.SessionId))
         {
             query = query.Where(x => x.SessionId == filter.SessionId);
         }
-        if (!String.IsNullOrWhiteSpace(filter.SubjectId))
+        if (!string.IsNullOrWhiteSpace(filter.SubjectId))
         {
             query = query.Where(x => x.SubjectId == filter.SubjectId);
         }
-        if (!String.IsNullOrWhiteSpace(filter.Type))
+        var types = filter.Types.Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
+        if (types.Any())
         {
-            query = query.Where(x => x.Type == filter.Type);
+            query = query.Where(x => types.Contains(x.Type));
         }
 
         var items = query.ToArray().AsEnumerable();

--- a/src/Open.IdentityServer/src/Stores/InMemory/InMemorySessionStore.cs
+++ b/src/Open.IdentityServer/src/Stores/InMemory/InMemorySessionStore.cs
@@ -4,8 +4,6 @@
 #nullable enable
 
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Open.IdentityServer.Models;
 

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Hosting/IdentityServerMiddlewareTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Hosting/IdentityServerMiddlewareTests.cs
@@ -1,13 +1,20 @@
 // Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Modified by Rock Solid Knowledge Ltd. Copyright in modifications 2026, Rock Solid Knowledge Ltd.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+#nullable enable
+
 using System;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using AwesomeAssertions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Open.IdentityServer.Extensions;
 using Open.IdentityServer.Hosting;
+using Open.IdentityServer.Models;
 using Open.IdentityServer.Services;
 using Xunit;
 
@@ -25,6 +32,7 @@ public class IdentityServerMiddlewareTests
     private readonly Mock<IUserSession> _userSession;
     private readonly Mock<IEventService> _eventService;
     private readonly Mock<IBackChannelLogoutService> _backChannelLogoutService;
+    private readonly IUserSessionEventsService userSessionEventsService;
     private readonly Mock<ITelemetryService> _telemetryService;
     private readonly Mock<ITrace> _trace;
     private readonly DefaultHttpContext _context;
@@ -41,6 +49,7 @@ public class IdentityServerMiddlewareTests
         _userSession = new Mock<IUserSession>();
         _eventService = new Mock<IEventService>();
         _backChannelLogoutService = new Mock<IBackChannelLogoutService>();
+        userSessionEventsService = Mock.Of<IUserSessionEventsService>();
         _telemetryService = new Mock<ITelemetryService>();
         _trace = new Mock<ITrace>();
         _telemetryService.Setup(t => t.Trace(It.IsAny<string>(), It.IsAny<string>()))
@@ -57,7 +66,7 @@ public class IdentityServerMiddlewareTests
     private async Task InvokeSubjectMiddleware()
     {
         await _subject.Invoke(_context, _router.Object, _userSession.Object, 
-            _eventService.Object, _backChannelLogoutService.Object, _telemetryService?.Object);
+            _eventService.Object, _backChannelLogoutService.Object, userSessionEventsService, _telemetryService?.Object);
     }
 
     [Fact]
@@ -207,5 +216,51 @@ public class IdentityServerMiddlewareTests
             _context.Request.Path.ToString()), 
             Times.Once);
         activeRequestDisposable.Verify(x => x.Dispose(), Times.Once);
+    }
+    
+    [Fact]
+    public async Task Invoke_WhenSignOutCalled_ShouldCallHandleUserSessionLogout_OnIUserSessionEventsService()
+    {
+        string sessionId = "session-id";
+        string subjectId = "subject-id";
+        string[] clientIds = ["clientId1", "clientId2", "clientId3"];
+        ClaimsPrincipal user = new ClaimsPrincipal(new ClaimsIdentity([
+            new Claim(JwtClaimTypes.Subject, subjectId, ClaimValueTypes.String, "FakeIssuer"),
+        ]));
+        
+        // Manually invoke the OnStarting callback to test that user session events service is called
+        var responseFeatureMock = Mock.Of<IHttpResponseFeature>();
+        Mock.Get(responseFeatureMock)
+            .Setup(x => x.OnStarting(It.IsAny<Func<object, Task>>(), It.IsAny<object>()))
+            .Callback<Func<object, Task>, object>((callback, state) => { callback.Invoke(state); });
+        _context.Features[typeof(IHttpResponseFeature)] = responseFeatureMock;
+        
+        _context.SetSignOutCalled();
+
+        _userSession.Setup(x => x.GetClientListAsync())
+            .ReturnsAsync(clientIds);
+        _userSession.Setup(x => x.GetSessionIdAsync())
+            .ReturnsAsync(sessionId);
+        _userSession.Setup(x => x.GetUserAsync())
+            .ReturnsAsync(user);
+
+        _userSession.Setup(x => x.RemoveSessionIdCookieAsync()).Returns(Task.CompletedTask);
+
+        UserSessionEventContext? actualUserSessionEventCtx = null;
+        Mock.Get(userSessionEventsService)
+            .Setup(x => x.HandleUserSessionLogout(It.IsAny<UserSessionEventContext>()))
+            .Callback<UserSessionEventContext>((sessionEventContext) => { actualUserSessionEventCtx = sessionEventContext; });
+        
+        await InvokeSubjectMiddleware();
+
+        _userSession.Verify(x => x.RemoveSessionIdCookieAsync(), Times.Once);
+        
+        Mock.Get(userSessionEventsService)
+            .Verify(x => x.HandleUserSessionLogout(It.IsAny<UserSessionEventContext>()), Times.Once);
+
+        actualUserSessionEventCtx.Should().NotBeNull();
+        actualUserSessionEventCtx.SessionId.Should().BeEquivalentTo(sessionId);
+        actualUserSessionEventCtx.SubjectId.Should().BeEquivalentTo(subjectId);
+        actualUserSessionEventCtx.ClientIds.Should().BeEquivalentTo(clientIds);
     }
 }

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Services/Default/DefaultUserSessionEventsServiceTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Services/Default/DefaultUserSessionEventsServiceTests.cs
@@ -1,0 +1,343 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Open.IdentityServer.Configuration;
+using Open.IdentityServer.Models;
+using Open.IdentityServer.Services;
+using Open.IdentityServer.Services.Default;
+using Open.IdentityServer.Stores;
+using Open.IdentityServer.UnitTests.Common;
+using Xunit;
+
+namespace Open.IdentityServer.UnitTests.Services.Default;
+
+public class DefaultUserSessionEventsServiceTests
+{
+    private readonly IBackChannelLogoutService backChannelLogoutService = Mock.Of<IBackChannelLogoutService>();
+    private readonly IClientStore clientStore = Mock.Of<IClientStore>();
+    private readonly IPersistedGrantStore persistedGrantStore = Mock.Of<IPersistedGrantStore>();
+    private readonly IdentityServerOptions idsOptions = new();
+    private readonly ILogger<DefaultUserSessionEventsService> logger = TestLogger.Create<DefaultUserSessionEventsService>();
+    
+    private DefaultUserSessionEventsService CreateSut() => new(clientStore, persistedGrantStore, backChannelLogoutService, idsOptions, logger);
+
+    [Fact]
+    public async Task HandleUserSessionLogout_WhenNoClientIdsInSession_ShouldDoNothing()
+    {
+        UserSessionEventContext userSessionCtx = new()
+        {
+            SubjectId = "fakeSubject",
+            SessionId = "fakeSession",
+            ClientIds = []
+        };
+        
+        DefaultUserSessionEventsService sut = CreateSut();
+
+        await sut.HandleUserSessionLogout(userSessionCtx);
+        
+        Mock.Get(persistedGrantStore)
+            .Verify(x => x.RemoveAllAsync(It.IsAny<PersistedGrantFilter>()), Times.Never);
+        Mock.Get(backChannelLogoutService)
+            .Verify(x => x.SendLogoutNotificationsAsync(It.IsAny<LogoutNotificationContext>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleUserSessionLogout_WhenServerDefaultCoordinateLifetimeSettingIsTrue_ShouldTriggerSessionCoordinationForClientsWithSettingEnabledAndFalse()
+    {
+        idsOptions.Authentication.CoordinateClientLifetimesWithUserSession = true;
+        
+        List<Client> clients = [
+            new() { ClientId = "fake-client-one", CoordinateLifetimeWithUserSession = null },
+            new() { ClientId = "fake-client-two", CoordinateLifetimeWithUserSession = true },
+            new() { ClientId = "fake-client-three", CoordinateLifetimeWithUserSession = false },
+        ];
+
+        SetupClientStore(clients);
+        UserSessionEventContext userSessionCtx = new()
+        {
+            SubjectId = "fakeSubject",
+            SessionId = "fakeSession",
+            ClientIds = clients.Select(x => x.ClientId).ToArray()
+        };
+        
+        DefaultUserSessionEventsService sut = CreateSut();
+
+        await sut.HandleUserSessionLogout(userSessionCtx);
+        
+        Mock.Get(persistedGrantStore)
+            .Verify(x => x.RemoveAllAsync(It.Is<PersistedGrantFilter>(x => 
+                x.SubjectId == "fakeSubject" &&
+                x.SessionId == "fakeSession" &&
+                x.ClientIds.Contains("fake-client-one") &&
+                x.ClientIds.Contains("fake-client-two") &&
+                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.RefreshToken) &&
+                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.ReferenceToken) &&
+                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.AuthorizationCode))));
+        
+        Mock.Get(backChannelLogoutService)
+            .Verify(x => x.SendLogoutNotificationsAsync(It.Is<LogoutNotificationContext>(x =>
+                x.SubjectId == "fakeSubject" &&
+                x.SessionId == "fakeSession" &&
+                x.ClientIds.Contains("fake-client-one") &&
+                x.ClientIds.Contains("fake-client-two") &&
+                x.ClientIds.Contains("fake-client-three"))));
+    }
+
+    [Fact]
+    public async Task HandleUserSessionLogout_WhenServerDefaultCoordinateLifetimeSettingIsFalse_ShouldTriggerSessionCoordinationForClientsWithSettingEnabledOnly()
+    {
+        idsOptions.Authentication.CoordinateClientLifetimesWithUserSession = false;
+        
+        List<Client> clients = [
+            new() { ClientId = "fake-client-one", CoordinateLifetimeWithUserSession = null },
+            new() { ClientId = "fake-client-two", CoordinateLifetimeWithUserSession = true },
+            new() { ClientId = "fake-client-three", CoordinateLifetimeWithUserSession = false },
+        ];
+        
+        SetupClientStore(clients);
+        UserSessionEventContext userSessionCtx = new()
+        {
+            SubjectId = "fakeSubject",
+            SessionId = "fakeSession",
+            ClientIds = clients.Select(x => x.ClientId).ToArray()
+        };
+        
+        DefaultUserSessionEventsService sut = CreateSut();
+
+        await sut.HandleUserSessionLogout(userSessionCtx);
+        
+        Mock.Get(persistedGrantStore)
+            .Verify(x => x.RemoveAllAsync(It.Is<PersistedGrantFilter>(x => 
+                x.SubjectId == "fakeSubject" &&
+                x.SessionId == "fakeSession" &&
+                x.ClientIds.Contains("fake-client-two") &&
+                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.RefreshToken) &&
+                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.ReferenceToken) &&
+                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.AuthorizationCode))));
+        
+        Mock.Get(backChannelLogoutService)
+            .Verify(x => x.SendLogoutNotificationsAsync(It.Is<LogoutNotificationContext>(x =>
+                x.SubjectId == "fakeSubject" &&
+                x.SessionId == "fakeSession" &&
+                x.ClientIds.Contains("fake-client-one") &&
+                x.ClientIds.Contains("fake-client-two") &&
+                x.ClientIds.Contains("fake-client-three"))));
+    }
+
+    [Fact]
+    public async Task HandleUserSessionLogout_WhenClientIdNotFound_ShouldExcludeClientIdsNotFound()
+    {
+        idsOptions.Authentication.CoordinateClientLifetimesWithUserSession = false;
+        
+        List<Client> clients = [
+            new() { ClientId = "fake-client-one", CoordinateLifetimeWithUserSession = true },
+        ];
+        
+        SetupClientStore(clients);
+        UserSessionEventContext userSessionCtx = new()
+        {
+            SubjectId = "fakeSubject",
+            SessionId = "fakeSession",
+            ClientIds = [..clients.Select(x => x.ClientId).ToList(), "fake-non-found"],
+        };
+        
+        DefaultUserSessionEventsService sut = CreateSut();
+
+        await sut.HandleUserSessionLogout(userSessionCtx);
+        
+        Mock.Get(persistedGrantStore)
+            .Verify(x => x.RemoveAllAsync(It.Is<PersistedGrantFilter>(x => 
+                x.SubjectId == "fakeSubject" &&
+                x.SessionId == "fakeSession" &&
+                x.ClientIds.Contains("fake-client-one") &&
+                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.RefreshToken) &&
+                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.ReferenceToken) &&
+                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.AuthorizationCode))));
+        
+        Mock.Get(backChannelLogoutService)
+            .Verify(x => x.SendLogoutNotificationsAsync(It.Is<LogoutNotificationContext>(x =>
+                x.SubjectId == "fakeSubject" &&
+                x.SessionId == "fakeSession" &&
+                x.ClientIds.Contains("fake-client-one") &&
+                x.ClientIds.Contains("fake-non-found"))));
+    }
+    
+    [Fact]
+    public async Task HandleUserSessionExpiry_WhenNoClientIdsInSession_ShouldDoNothing()
+    {
+        UserSessionEventContext userSessionCtx = new()
+        {
+            SubjectId = "fakeSubject",
+            SessionId = "fakeSession",
+            ClientIds = [],
+        };
+        
+        DefaultUserSessionEventsService sut = CreateSut();
+
+        await sut.HandleUserSessionExpiry(userSessionCtx);
+        
+        Mock.Get(persistedGrantStore)
+            .Verify(x => x.RemoveAllAsync(It.IsAny<PersistedGrantFilter>()), Times.Never);
+        Mock.Get(backChannelLogoutService)
+            .Verify(x => x.SendLogoutNotificationsAsync(It.IsAny<LogoutNotificationContext>()), Times.Never);
+    }
+    
+    [Fact]
+    public async Task HandleUserSessionExpiry_WhenServerDefaultCoordinateLifetimeSettingIsTrue_ShouldTriggerSessionCoordinationForClientsWithSettingEnabledAndFalse()
+    {
+        idsOptions.Authentication.CoordinateClientLifetimesWithUserSession = true;
+        
+        List<Client> clients = [
+            new() { ClientId = "fake-client-one", CoordinateLifetimeWithUserSession = null },
+            new() { ClientId = "fake-client-two", CoordinateLifetimeWithUserSession = true },
+            new() { ClientId = "fake-client-three", CoordinateLifetimeWithUserSession = false },
+        ];
+        
+        SetupClientStore(clients);
+        UserSessionEventContext userSessionCtx = new()
+        {
+            SubjectId = "fakeSubject",
+            SessionId = "fakeSession",
+            ClientIds = clients.Select(x => x.ClientId).ToArray(),
+        };
+        
+        DefaultUserSessionEventsService sut = CreateSut();
+
+        await sut.HandleUserSessionExpiry(userSessionCtx);
+        
+        Mock.Get(persistedGrantStore)
+            .Verify(x => x.RemoveAllAsync(It.Is<PersistedGrantFilter>(x => 
+                x.SubjectId == "fakeSubject" &&
+                x.SessionId == "fakeSession" &&
+                x.ClientIds.Contains("fake-client-one") &&
+                x.ClientIds.Contains("fake-client-two") &&
+                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.RefreshToken) &&
+                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.ReferenceToken) &&
+                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.AuthorizationCode))));
+        
+        Mock.Get(backChannelLogoutService)
+            .Verify(x => x.SendLogoutNotificationsAsync(It.Is<LogoutNotificationContext>(x =>
+                x.SubjectId == "fakeSubject" &&
+                x.SessionId == "fakeSession" &&
+                x.ClientIds.Contains("fake-client-one") &&
+                x.ClientIds.Contains("fake-client-two"))));
+    }
+    
+    [Fact]
+    public async Task HandleUserSessionExpiry_WhenServerDefaultCoordinateLifetimeSettingIsFalse_ShouldTriggerSessionCoordinationForClientsWithSettingEnabledOnly()
+    {
+        idsOptions.Authentication.CoordinateClientLifetimesWithUserSession = false;
+        
+        List<Client> clients = [
+            new() { ClientId = "fake-client-one", CoordinateLifetimeWithUserSession = null },
+            new() { ClientId = "fake-client-two", CoordinateLifetimeWithUserSession = true },
+            new() { ClientId = "fake-client-three", CoordinateLifetimeWithUserSession = false },
+        ];
+        
+        SetupClientStore(clients);
+        UserSessionEventContext userSessionCtx = new()
+        {
+            SubjectId = "fakeSubject",
+            SessionId = "fakeSession",
+            ClientIds = clients.Select(x => x.ClientId).ToArray(),
+        };
+        
+        DefaultUserSessionEventsService sut = CreateSut();
+
+        await sut.HandleUserSessionExpiry(userSessionCtx);
+        
+        Mock.Get(persistedGrantStore)
+            .Verify(x => x.RemoveAllAsync(It.Is<PersistedGrantFilter>(x => 
+                x.SubjectId == "fakeSubject" &&
+                x.SessionId == "fakeSession" &&
+                x.ClientIds.Contains("fake-client-two") &&
+                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.RefreshToken) &&
+                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.ReferenceToken) &&
+                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.AuthorizationCode))));
+        
+        Mock.Get(backChannelLogoutService)
+            .Verify(x => x.SendLogoutNotificationsAsync(It.Is<LogoutNotificationContext>(x =>
+                x.SubjectId == "fakeSubject" &&
+                x.SessionId == "fakeSession" &&
+                x.ClientIds.Contains("fake-client-two"))));
+    }
+    
+    [Fact]
+    public async Task HandleUserSessionExpiry_WhenExpiredSessionsTriggerBackchannelLogoutIsTrue_ShouldTriggerBackchannelLogoutOnAllClientIgnoringCoordinationSetting()
+    {
+        idsOptions.ServerSideSessions.ExpiredSessionsTriggerBackchannelLogout = true;
+        
+        List<Client> clients = [
+            new() { ClientId = "fake-client-one", CoordinateLifetimeWithUserSession = null },
+            new() { ClientId = "fake-client-two", CoordinateLifetimeWithUserSession = true },
+            new() { ClientId = "fake-client-three", CoordinateLifetimeWithUserSession = false },
+        ];
+        
+        SetupClientStore(clients);
+        UserSessionEventContext userSessionCtx = new()
+        {
+            SubjectId = "fakeSubject",
+            SessionId = "fakeSession",
+            ClientIds = clients.Select(x => x.ClientId).ToArray(),
+        };
+        
+        DefaultUserSessionEventsService sut = CreateSut();
+
+        await sut.HandleUserSessionExpiry(userSessionCtx);
+        
+        Mock.Get(persistedGrantStore)
+            .Verify(x => x.RemoveAllAsync(It.Is<PersistedGrantFilter>(x => 
+                x.SubjectId == "fakeSubject" &&
+                x.SessionId == "fakeSession" &&
+                x.ClientIds.Contains("fake-client-two") &&
+                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.RefreshToken) &&
+                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.ReferenceToken) &&
+                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.AuthorizationCode))));
+        
+        Mock.Get(backChannelLogoutService)
+            .Verify(x => x.SendLogoutNotificationsAsync(It.Is<LogoutNotificationContext>(x =>
+                x.SubjectId == "fakeSubject" &&
+                x.SessionId == "fakeSession" &&
+                x.ClientIds.Contains("fake-client-one") &&
+                x.ClientIds.Contains("fake-client-two") &&
+                x.ClientIds.Contains("fake-client-three"))));
+    }
+    
+    [Fact]
+    public async Task HandleUserSessionExpiry_WhenClientIdNotFound_ShouldExcludeClientIdsNotFound()
+    {
+        UserSessionEventContext userSessionCtx = new()
+        {
+            SubjectId = "fakeSubject",
+            SessionId = "fakeSession",
+            ClientIds = ["fake-non-found"],
+        };
+        
+        DefaultUserSessionEventsService sut = CreateSut();
+
+        await sut.HandleUserSessionExpiry(userSessionCtx);
+        
+        Mock.Get(persistedGrantStore)
+            .Verify(x => x.RemoveAllAsync(It.IsAny<PersistedGrantFilter>()), Times.Never);
+        
+        Mock.Get(backChannelLogoutService)
+            .Verify(x => x.SendLogoutNotificationsAsync(It.IsAny<LogoutNotificationContext>()), Times.Never);
+    }
+
+    private void SetupClientStore(IEnumerable<Client> clients)
+    {
+        foreach (var client in clients)
+        {
+            Mock.Get(clientStore)
+                .Setup(x => x.FindClientByIdAsync(client.ClientId))
+                .ReturnsAsync(client);
+        }
+    }
+}

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Services/Default/DefaultUserSessionEventsServiceTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Services/Default/DefaultUserSessionEventsServiceTests.cs
@@ -3,9 +3,11 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using AwesomeAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Open.IdentityServer.Configuration;
@@ -24,10 +26,40 @@ public class DefaultUserSessionEventsServiceTests
     private readonly IClientStore clientStore = Mock.Of<IClientStore>();
     private readonly IPersistedGrantStore persistedGrantStore = Mock.Of<IPersistedGrantStore>();
     private readonly IdentityServerOptions idsOptions = new();
+    private readonly ITelemetryService telemetry = Mock.Of<ITelemetryService>();
+    private readonly ITrace trace = Mock.Of<ITrace>();
     private readonly ILogger<DefaultUserSessionEventsService> logger = TestLogger.Create<DefaultUserSessionEventsService>();
     
-    private DefaultUserSessionEventsService CreateSut() => new(clientStore, persistedGrantStore, backChannelLogoutService, idsOptions, logger);
+    private DefaultUserSessionEventsService CreateSut() => new(clientStore, persistedGrantStore, backChannelLogoutService, idsOptions, telemetry, logger);
 
+    [Theory]
+    [InlineData("subjectId", null)]
+    [InlineData("subjectId", "")]
+    [InlineData("subjectId", "  ")]
+    [InlineData(null, "subjectId")]
+    [InlineData("", "subjectId")]
+    [InlineData("  ", "subjectId")]
+    public async Task HandleUserSessionLogout_WhenInvalidSubjectId_ShouldThrowArgumentException(string subjectId, string sessionId)
+    {
+        UserSessionEventContext userSessionCtx = new()
+        {
+            SubjectId = subjectId,
+            SessionId = sessionId,
+            ClientIds = []
+        };
+        
+        DefaultUserSessionEventsService sut = CreateSut();
+
+        Func<Task> act = async () => await sut.HandleUserSessionLogout(userSessionCtx);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+        
+        Mock.Get(persistedGrantStore)
+            .Verify(x => x.RemoveAllAsync(It.IsAny<PersistedGrantFilter>()), Times.Never);
+        Mock.Get(backChannelLogoutService)
+            .Verify(x => x.SendLogoutNotificationsAsync(It.IsAny<LogoutNotificationContext>()), Times.Never);
+    }
+    
     [Fact]
     public async Task HandleUserSessionLogout_WhenNoClientIdsInSession_ShouldDoNothing()
     {
@@ -75,11 +107,11 @@ public class DefaultUserSessionEventsServiceTests
             .Verify(x => x.RemoveAllAsync(It.Is<PersistedGrantFilter>(x => 
                 x.SubjectId == "fakeSubject" &&
                 x.SessionId == "fakeSession" &&
-                x.ClientIds.Contains("fake-client-one") &&
-                x.ClientIds.Contains("fake-client-two") &&
-                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.RefreshToken) &&
-                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.ReferenceToken) &&
-                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.AuthorizationCode))));
+                Enumerable.Contains(x.ClientIds, "fake-client-one") &&
+                Enumerable.Contains(x.ClientIds, "fake-client-two") &&
+                Enumerable.Contains(x.Types, IdentityServerConstants.PersistedGrantTypes.RefreshToken) &&
+                Enumerable.Contains(x.Types, IdentityServerConstants.PersistedGrantTypes.ReferenceToken) &&
+                Enumerable.Contains(x.Types, IdentityServerConstants.PersistedGrantTypes.AuthorizationCode))));
         
         Mock.Get(backChannelLogoutService)
             .Verify(x => x.SendLogoutNotificationsAsync(It.Is<LogoutNotificationContext>(x =>
@@ -117,10 +149,10 @@ public class DefaultUserSessionEventsServiceTests
             .Verify(x => x.RemoveAllAsync(It.Is<PersistedGrantFilter>(x => 
                 x.SubjectId == "fakeSubject" &&
                 x.SessionId == "fakeSession" &&
-                x.ClientIds.Contains("fake-client-two") &&
-                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.RefreshToken) &&
-                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.ReferenceToken) &&
-                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.AuthorizationCode))));
+                Enumerable.Contains(x.ClientIds, "fake-client-two") &&
+                Enumerable.Contains(x.Types, IdentityServerConstants.PersistedGrantTypes.RefreshToken) &&
+                Enumerable.Contains(x.Types, IdentityServerConstants.PersistedGrantTypes.ReferenceToken) &&
+                Enumerable.Contains(x.Types, IdentityServerConstants.PersistedGrantTypes.AuthorizationCode))));
         
         Mock.Get(backChannelLogoutService)
             .Verify(x => x.SendLogoutNotificationsAsync(It.Is<LogoutNotificationContext>(x =>
@@ -156,10 +188,10 @@ public class DefaultUserSessionEventsServiceTests
             .Verify(x => x.RemoveAllAsync(It.Is<PersistedGrantFilter>(x => 
                 x.SubjectId == "fakeSubject" &&
                 x.SessionId == "fakeSession" &&
-                x.ClientIds.Contains("fake-client-one") &&
-                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.RefreshToken) &&
-                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.ReferenceToken) &&
-                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.AuthorizationCode))));
+                Enumerable.Contains(x.ClientIds, "fake-client-one") &&
+                Enumerable.Contains(x.Types, IdentityServerConstants.PersistedGrantTypes.RefreshToken) &&
+                Enumerable.Contains(x.Types, IdentityServerConstants.PersistedGrantTypes.ReferenceToken) &&
+                Enumerable.Contains(x.Types, IdentityServerConstants.PersistedGrantTypes.AuthorizationCode))));
         
         Mock.Get(backChannelLogoutService)
             .Verify(x => x.SendLogoutNotificationsAsync(It.Is<LogoutNotificationContext>(x =>
@@ -167,6 +199,34 @@ public class DefaultUserSessionEventsServiceTests
                 x.SessionId == "fakeSession" &&
                 x.ClientIds.Contains("fake-client-one") &&
                 x.ClientIds.Contains("fake-non-found"))));
+    }
+
+    [Theory]
+    [InlineData("subjectId", null)]
+    [InlineData("subjectId", "")]
+    [InlineData("subjectId", "  ")]
+    [InlineData(null, "subjectId")]
+    [InlineData("", "subjectId")]
+    [InlineData("  ", "subjectId")]
+    public async Task HandleUserSessionExpiry_WhenInvalidSubjectId_ShouldThrowArgumentException(string subjectId, string sessionId)
+    {
+        UserSessionEventContext userSessionCtx = new()
+        {
+            SubjectId = subjectId,
+            SessionId = sessionId,
+            ClientIds = []
+        };
+        
+        DefaultUserSessionEventsService sut = CreateSut();
+
+        Func<Task> act = async () => await sut.HandleUserSessionExpiry(userSessionCtx);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+        
+        Mock.Get(persistedGrantStore)
+            .Verify(x => x.RemoveAllAsync(It.IsAny<PersistedGrantFilter>()), Times.Never);
+        Mock.Get(backChannelLogoutService)
+            .Verify(x => x.SendLogoutNotificationsAsync(It.IsAny<LogoutNotificationContext>()), Times.Never);
     }
     
     [Fact]
@@ -216,11 +276,11 @@ public class DefaultUserSessionEventsServiceTests
             .Verify(x => x.RemoveAllAsync(It.Is<PersistedGrantFilter>(x => 
                 x.SubjectId == "fakeSubject" &&
                 x.SessionId == "fakeSession" &&
-                x.ClientIds.Contains("fake-client-one") &&
-                x.ClientIds.Contains("fake-client-two") &&
-                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.RefreshToken) &&
-                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.ReferenceToken) &&
-                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.AuthorizationCode))));
+                Enumerable.Contains(x.ClientIds, "fake-client-one") &&
+                Enumerable.Contains(x.ClientIds, "fake-client-two") &&
+                Enumerable.Contains(x.Types, IdentityServerConstants.PersistedGrantTypes.RefreshToken) &&
+                Enumerable.Contains(x.Types, IdentityServerConstants.PersistedGrantTypes.ReferenceToken) &&
+                Enumerable.Contains(x.Types, IdentityServerConstants.PersistedGrantTypes.AuthorizationCode))));
         
         Mock.Get(backChannelLogoutService)
             .Verify(x => x.SendLogoutNotificationsAsync(It.Is<LogoutNotificationContext>(x =>
@@ -257,10 +317,10 @@ public class DefaultUserSessionEventsServiceTests
             .Verify(x => x.RemoveAllAsync(It.Is<PersistedGrantFilter>(x => 
                 x.SubjectId == "fakeSubject" &&
                 x.SessionId == "fakeSession" &&
-                x.ClientIds.Contains("fake-client-two") &&
-                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.RefreshToken) &&
-                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.ReferenceToken) &&
-                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.AuthorizationCode))));
+                Enumerable.Contains(x.ClientIds, "fake-client-two") &&
+                Enumerable.Contains(x.Types, IdentityServerConstants.PersistedGrantTypes.RefreshToken) &&
+                Enumerable.Contains(x.Types, IdentityServerConstants.PersistedGrantTypes.ReferenceToken) &&
+                Enumerable.Contains(x.Types, IdentityServerConstants.PersistedGrantTypes.AuthorizationCode))));
         
         Mock.Get(backChannelLogoutService)
             .Verify(x => x.SendLogoutNotificationsAsync(It.Is<LogoutNotificationContext>(x =>
@@ -296,10 +356,10 @@ public class DefaultUserSessionEventsServiceTests
             .Verify(x => x.RemoveAllAsync(It.Is<PersistedGrantFilter>(x => 
                 x.SubjectId == "fakeSubject" &&
                 x.SessionId == "fakeSession" &&
-                x.ClientIds.Contains("fake-client-two") &&
-                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.RefreshToken) &&
-                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.ReferenceToken) &&
-                x.Types.Contains(IdentityServerConstants.PersistedGrantTypes.AuthorizationCode))));
+                Enumerable.Contains(x.ClientIds, "fake-client-two") &&
+                Enumerable.Contains(x.Types, IdentityServerConstants.PersistedGrantTypes.RefreshToken) &&
+                Enumerable.Contains(x.Types, IdentityServerConstants.PersistedGrantTypes.ReferenceToken) &&
+                Enumerable.Contains(x.Types, IdentityServerConstants.PersistedGrantTypes.AuthorizationCode))));
         
         Mock.Get(backChannelLogoutService)
             .Verify(x => x.SendLogoutNotificationsAsync(It.Is<LogoutNotificationContext>(x =>
@@ -329,6 +389,40 @@ public class DefaultUserSessionEventsServiceTests
         
         Mock.Get(backChannelLogoutService)
             .Verify(x => x.SendLogoutNotificationsAsync(It.IsAny<LogoutNotificationContext>()), Times.Never);
+    }
+    
+    [Fact]
+    public async Task HandleUserSessionLogout_WhenCalled_ShouldInitiateTelemetryTrace()
+    {
+        Mock.Get(telemetry)
+            .Setup(t => t.Trace(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<string>()))
+            .Returns(trace);
+        
+        DefaultUserSessionEventsService sut = CreateSut();
+        await sut.HandleUserSessionLogout(new UserSessionEventContext { SessionId = "session", SubjectId = "subject" });
+        
+        Mock.Get(telemetry)
+            .Verify(t => t.Trace(
+            TelemetryConstants.TraceCategories.Services, sut, "HandleUserSessionLogout"));
+        Mock.Get(trace)
+            .Verify(t => t.Dispose(), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleUserSessionExpiry_WhenCalled_ShouldInitiateTelemetryTrace()
+    {
+        Mock.Get(telemetry)
+            .Setup(t => t.Trace(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<string>()))
+            .Returns(trace);
+        
+        DefaultUserSessionEventsService sut = CreateSut();
+        await sut.HandleUserSessionExpiry(new UserSessionEventContext { SessionId = "session", SubjectId = "subject" });
+        
+        Mock.Get(telemetry)
+            .Verify(t => t.Trace(
+            TelemetryConstants.TraceCategories.Services, sut, "HandleUserSessionExpiry"));
+        Mock.Get(trace)
+            .Verify(t => t.Dispose(), Times.Once);
     }
 
     private void SetupClientStore(IEnumerable<Client> clients)

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/InMemoryPersistedGrantStoreTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Stores/InMemoryPersistedGrantStoreTests.cs
@@ -38,17 +38,14 @@ public class InMemoryPersistedGrantStoreTests
     [Fact]
     public async Task GetAll_should_filter()
     {
-        await _subject.StoreAsync(new PersistedGrant() { Key = "key1", SubjectId = "sub1", ClientId = "client1", SessionId = "session1" });
-        await _subject.StoreAsync(new PersistedGrant() { Key = "key2", SubjectId = "sub1", ClientId = "client2", SessionId = "session1" });
-        await _subject.StoreAsync(new PersistedGrant() { Key = "key3", SubjectId = "sub1", ClientId = "client1", SessionId = "session2" });
-        await _subject.StoreAsync(new PersistedGrant() { Key = "key4", SubjectId = "sub1", ClientId = "client3", SessionId = "session2" });
-        await _subject.StoreAsync(new PersistedGrant() { Key = "key5", SubjectId = "sub1", ClientId = "client4", SessionId = "session3" });
-        await _subject.StoreAsync(new PersistedGrant() { Key = "key6", SubjectId = "sub1", ClientId = "client4", SessionId = "session4" });
-
-        await _subject.StoreAsync(new PersistedGrant() { Key = "key7", SubjectId = "sub2", ClientId = "client4", SessionId = "session4" });
-
-
-
+        await _subject.StoreAsync(new PersistedGrant() { Key = "key1", SubjectId = "sub1", ClientId = "client1", SessionId = "session1", Type = "typeA"});
+        await _subject.StoreAsync(new PersistedGrant() { Key = "key2", SubjectId = "sub1", ClientId = "client2", SessionId = "session1", Type = "typeB" });
+        await _subject.StoreAsync(new PersistedGrant() { Key = "key3", SubjectId = "sub1", ClientId = "client1", SessionId = "session2", Type = "typeB" });
+        await _subject.StoreAsync(new PersistedGrant() { Key = "key4", SubjectId = "sub1", ClientId = "client3", SessionId = "session2", Type = "typeA" });
+        await _subject.StoreAsync(new PersistedGrant() { Key = "key5", SubjectId = "sub1", ClientId = "client4", SessionId = "session3", Type = "typeC" });
+        await _subject.StoreAsync(new PersistedGrant() { Key = "key6", SubjectId = "sub1", ClientId = "client4", SessionId = "session4", Type = "typeA" });
+        await _subject.StoreAsync(new PersistedGrant() { Key = "key7", SubjectId = "sub2", ClientId = "client4", SessionId = "session4", Type = "typeC" });
+        
         (await _subject.GetAllAsync(new PersistedGrantFilter
             {
                 SubjectId = "sub1"
@@ -194,6 +191,25 @@ public class InMemoryPersistedGrantStoreTests
                 SessionId = "session5"
             }))
             .Select(x => x.Key).Should().BeEmpty();
+
+        (await _subject.GetAllAsync(new PersistedGrantFilter
+            {
+                ClientIds = ["client1", "client4"],
+            }))
+            .Select(x => x.Key).Should().BeEquivalentTo("key1", "key3", "key5", "key6", "key7");
+
+        (await _subject.GetAllAsync(new PersistedGrantFilter
+            {
+                Types = ["typeA", "typeC"],
+            }))
+            .Select(x => x.Key).Should().BeEquivalentTo("key1", "key4", "key5", "key6", "key7");
+
+        (await _subject.GetAllAsync(new PersistedGrantFilter
+            {
+                ClientIds = ["client2", "client3"],
+                Types = ["typeA", "typeB"],
+            }))
+            .Select(x => x.Key).Should().BeEquivalentTo("key2", "key4");
     }
 
     [Fact]
@@ -521,17 +537,73 @@ public class InMemoryPersistedGrantStoreTests
             (await _subject.GetAsync("key6")).Should().NotBeNull();
             (await _subject.GetAsync("key7")).Should().NotBeNull();
         }
+        {
+            await Populate();
+            await _subject.RemoveAllAsync(new PersistedGrantFilter
+            {
+                ClientIds = ["client1", "client2"],
+            });
+            (await _subject.GetAsync("key1")).Should().BeNull();
+            (await _subject.GetAsync("key2")).Should().BeNull();
+            (await _subject.GetAsync("key3")).Should().BeNull();
+            (await _subject.GetAsync("key4")).Should().NotBeNull();
+            (await _subject.GetAsync("key5")).Should().NotBeNull();
+            (await _subject.GetAsync("key6")).Should().NotBeNull();
+            (await _subject.GetAsync("key7")).Should().NotBeNull();
+        }
+        {
+            await Populate();
+            await _subject.RemoveAllAsync(new PersistedGrantFilter
+            {
+                Type = "typeA",
+            });
+            (await _subject.GetAsync("key1")).Should().BeNull();
+            (await _subject.GetAsync("key2")).Should().NotBeNull();
+            (await _subject.GetAsync("key3")).Should().NotBeNull();
+            (await _subject.GetAsync("key4")).Should().BeNull();
+            (await _subject.GetAsync("key5")).Should().NotBeNull();
+            (await _subject.GetAsync("key6")).Should().NotBeNull();
+            (await _subject.GetAsync("key7")).Should().BeNull();
+        }
+        {
+            await Populate();
+            await _subject.RemoveAllAsync(new PersistedGrantFilter
+            {
+                Types = ["typeB", "typeC"],
+            });
+            (await _subject.GetAsync("key1")).Should().NotBeNull();
+            (await _subject.GetAsync("key2")).Should().BeNull();
+            (await _subject.GetAsync("key3")).Should().BeNull();
+            (await _subject.GetAsync("key4")).Should().NotBeNull();
+            (await _subject.GetAsync("key5")).Should().BeNull();
+            (await _subject.GetAsync("key6")).Should().BeNull();
+            (await _subject.GetAsync("key7")).Should().NotBeNull();
+        }
+        {
+            await Populate();
+            await _subject.RemoveAllAsync(new PersistedGrantFilter
+            {
+                ClientIds = ["client3", "client4"],
+                Types = ["typeA", "typeC"],
+            });
+            (await _subject.GetAsync("key1")).Should().NotBeNull();
+            (await _subject.GetAsync("key2")).Should().NotBeNull();
+            (await _subject.GetAsync("key3")).Should().NotBeNull();
+            (await _subject.GetAsync("key4")).Should().BeNull();
+            (await _subject.GetAsync("key5")).Should().BeNull();
+            (await _subject.GetAsync("key6")).Should().BeNull();
+            (await _subject.GetAsync("key7")).Should().BeNull();
+        }
     }
 
     private async Task Populate()
     {
-        await _subject.StoreAsync(new PersistedGrant() { Key = "key1", SubjectId = "sub1", ClientId = "client1", SessionId = "session1" });
-        await _subject.StoreAsync(new PersistedGrant() { Key = "key2", SubjectId = "sub1", ClientId = "client2", SessionId = "session1" });
-        await _subject.StoreAsync(new PersistedGrant() { Key = "key3", SubjectId = "sub1", ClientId = "client1", SessionId = "session2" });
-        await _subject.StoreAsync(new PersistedGrant() { Key = "key4", SubjectId = "sub1", ClientId = "client3", SessionId = "session2" });
-        await _subject.StoreAsync(new PersistedGrant() { Key = "key5", SubjectId = "sub1", ClientId = "client4", SessionId = "session3" });
-        await _subject.StoreAsync(new PersistedGrant() { Key = "key6", SubjectId = "sub1", ClientId = "client4", SessionId = "session4" });
-
-        await _subject.StoreAsync(new PersistedGrant() { Key = "key7", SubjectId = "sub2", ClientId = "client4", SessionId = "session4" });
+        await _subject.StoreAsync(new PersistedGrant() { Key = "key1", SubjectId = "sub1", ClientId = "client1", SessionId = "session1", Type = "typeA" });
+        await _subject.StoreAsync(new PersistedGrant() { Key = "key2", SubjectId = "sub1", ClientId = "client2", SessionId = "session1", Type = "typeB" });
+        await _subject.StoreAsync(new PersistedGrant() { Key = "key3", SubjectId = "sub1", ClientId = "client1", SessionId = "session2", Type = "typeB" });
+        await _subject.StoreAsync(new PersistedGrant() { Key = "key4", SubjectId = "sub1", ClientId = "client3", SessionId = "session2", Type = "typeA" });
+        await _subject.StoreAsync(new PersistedGrant() { Key = "key5", SubjectId = "sub1", ClientId = "client4", SessionId = "session3", Type = "typeC" });
+        await _subject.StoreAsync(new PersistedGrant() { Key = "key6", SubjectId = "sub1", ClientId = "client4", SessionId = "session4", Type = "typeC" });
+        await _subject.StoreAsync(new PersistedGrant() { Key = "key7", SubjectId = "sub2", ClientId = "client4", SessionId = "session4", Type = "typeA" });
     }
 }

--- a/src/Storage/src/Extensions/PersistedGrantFilterExtensions.cs
+++ b/src/Storage/src/Extensions/PersistedGrantFilterExtensions.cs
@@ -4,6 +4,7 @@
 
 using Open.IdentityServer.Stores;
 using System;
+using System.Linq;
 
 namespace Open.IdentityServer.Extensions;
 
@@ -18,12 +19,12 @@ public static class PersistedGrantFilterExtensions
     /// <param name="filter"></param>
     public static void Validate(this PersistedGrantFilter filter)
     {
-        if (filter == null) throw new ArgumentNullException(nameof(filter));
+        ArgumentNullException.ThrowIfNull(filter);
 
-        if (String.IsNullOrWhiteSpace(filter.ClientId) &&
-            String.IsNullOrWhiteSpace(filter.SessionId) &&
-            String.IsNullOrWhiteSpace(filter.SubjectId) &&
-            String.IsNullOrWhiteSpace(filter.Type))
+        if (filter.ClientIds.Any(string.IsNullOrWhiteSpace) &&
+            string.IsNullOrWhiteSpace(filter.SessionId) &&
+            string.IsNullOrWhiteSpace(filter.SubjectId) &&
+            filter.Types.Any(string.IsNullOrWhiteSpace))
         {
             throw new ArgumentException("No filter values set.", nameof(filter));
         }

--- a/src/Storage/src/Models/Client.cs
+++ b/src/Storage/src/Models/Client.cs
@@ -431,8 +431,12 @@ public class Client
         }
     }
     
-    //Unused Compatibility Properties
+    /// <summary>
+    /// Gets or sets the coordinate lifetime with the user session
+    /// </summary>
+    public bool? CoordinateLifetimeWithUserSession { get; set; }
     
+    //Unused Compatibility Properties
     /// <summary>
     /// Gets or sets CIBA lifetime (Unused, added for compatibility)
     /// </summary>
@@ -442,11 +446,6 @@ public class Client
     /// Gets or sets polling interval (Unused, added for compatibility)
     /// </summary>
     public int? PollingInterval { get; set; }
-    
-    /// <summary>
-    /// Gets or sets coordinate lifetime with user session (Unused, added for compatibility)
-    /// </summary>
-    public bool? CoordinateLifetimeWithUserSession { get; set; }
     
     /// <summary>
     /// Gets or sets initiate login URI (Unused, added for compatibility)

--- a/src/Storage/src/Models/Client.cs
+++ b/src/Storage/src/Models/Client.cs
@@ -432,8 +432,13 @@ public class Client
     }
     
     /// <summary>
-    /// Gets or sets the coordinate lifetime with the user session
+    /// Used to override the server default value configured with IdentityServerOptions.Authentication.CoordinateClientLifetimesWithUserSession.
+    /// Specifies if the user session ending should revoke client revocable tokens, and also if token validation should
+    /// check for a valid user session.
     /// </summary>
+    /// <value>
+    /// <c>true</c> if coordination enabled; <c>false</c> if coordination disabled; otherwise, <c>null</c>.
+    /// </value>
     public bool? CoordinateLifetimeWithUserSession { get; set; }
     
     //Unused Compatibility Properties

--- a/src/Storage/src/Stores/PersistedGrantFilter.cs
+++ b/src/Storage/src/Stores/PersistedGrantFilter.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+using System.Linq;
+
 namespace Open.IdentityServer.Stores;
 
 /// <summary>
@@ -19,14 +21,32 @@ public class PersistedGrantFilter
     /// Session id used for the grant.
     /// </summary>
     public string SessionId { get; set; }
-        
+
     /// <summary>
-    /// Client id the grant was issued to.
+    /// Client id the grant was issued to. For backwards compatibility.
     /// </summary>
-    public string ClientId { get; set; }
-        
+    public string ClientId
+    {
+        init => ClientIds = [value];
+        get => ClientIds.FirstOrDefault();
+    }
+    
     /// <summary>
-    /// The type of grant.
+    /// Client ids the grant was issued to. Multiple elements in array interpreted as a logic 'OR' for the client id property.
     /// </summary>
-    public string Type { get; set; }
+    public string[] ClientIds { get; set; } = [];
+    
+    /// <summary>
+    /// The type of grant. For backwards compatibility.
+    /// </summary>
+    public string Type
+    {
+        init => Types = [value];
+        get => Types.FirstOrDefault();
+    }
+    
+    /// <summary>
+    /// The type of grant. Multiple elements in array interpreted as a logic 'OR' for the type property.
+    /// </summary>
+    public string[] Types { get; set; } = [];
 }


### PR DESCRIPTION
## Description

- Added server-side session related settings
- Added client lifetime updates on session end and expiry
- Added support for multiple clien ids and types in persisted grant filters

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

Tests have been written alongside new classes. Also, some manual testing of the functionality on my machine before and after the changes. 

## LLM Usage

n/a

## Other context

n/a