### PR TITLE
Generic mapper tests

### DIFF
--- a/src/EntityFramework.Storage/src/Mappers/ClientMappingExtensions.cs
+++ b/src/EntityFramework.Storage/src/Mappers/ClientMappingExtensions.cs
@@ -177,6 +177,7 @@ public static class ClientMappingExtensions
                 ClientClaimsPrefix = clientModel.ClientClaimsPrefix,
                 PairWiseSubjectSalt = clientModel.PairWiseSubjectSalt,
                 UserSsoLifetime = clientModel.UserSsoLifetime,
+                UserCodeType = clientModel.UserCodeType,
                 DeviceCodeLifetime = clientModel.DeviceCodeLifetime,
                 AllowedCorsOrigins = clientModel.AllowedCorsOrigins?.Select(x => new ClientCorsOrigin { Origin = x }).ToList() ?? [],
                 Properties = clientModel.Properties.ToEntityList<Entities.ClientProperty>(),

--- a/src/EntityFramework.Storage/test/UnitTests/Mappers/ApiResourceMappersTests.cs
+++ b/src/EntityFramework.Storage/test/UnitTests/Mappers/ApiResourceMappersTests.cs
@@ -139,4 +139,25 @@ public class ApiResourceMappersTests
         var model = entity.ToModel();
         model.ApiSecrets.First().Type.Should().Be(def.ApiSecrets.First().Type);
     }
+
+    [Fact]
+    public void ToEntity_maps_all_properties()
+    {
+        new MappingVerifier<ApiResource, Entities.ApiResource>()
+            .ExcludeDestinationProperties(
+                // Database-assigned or entity-managed fields not sourced from the model
+                nameof(Entities.ApiResource.Id),
+                nameof(Entities.ApiResource.Created),
+                nameof(Entities.ApiResource.Updated),
+                nameof(Entities.ApiResource.LastAccessed),
+                nameof(Entities.ApiResource.NonEditable))
+            .Verify(model => model.ToEntity());
+    }
+
+    [Fact]
+    public void ToModel_maps_all_properties()
+    {
+        new MappingVerifier<Entities.ApiResource, ApiResource>()
+            .Verify(entity => entity.ToModel());
+    }
 }

--- a/src/EntityFramework.Storage/test/UnitTests/Mappers/ClientMappersTests.cs
+++ b/src/EntityFramework.Storage/test/UnitTests/Mappers/ClientMappersTests.cs
@@ -97,4 +97,46 @@ public class ClientMappersTests
         model.ProtocolType.Should().Be(def.ProtocolType);
         model.ClientSecrets.First().Type.Should().Be(def.ClientSecrets.First().Type);
     }
+
+    [Fact]
+    public void ToEntity_maps_all_properties()
+    {
+        new MappingVerifier<Client, Entities.Client>()
+            .ExcludeDestinationProperties(
+                // Database-assigned or entity-managed fields not sourced from the model
+                nameof(Entities.Client.Id),
+                nameof(Entities.Client.Created),
+                nameof(Entities.Client.Updated),
+                nameof(Entities.Client.LastAccessed),
+                nameof(Entities.Client.NonEditable),
+                // Compatibility properties intentionally not mapped
+                nameof(Entities.Client.CibaLifetime),
+                nameof(Entities.Client.PollingInterval),
+                nameof(Entities.Client.CoordinateLifetimeWithUserSession),
+                nameof(Entities.Client.InitiateLoginUri),
+                nameof(Entities.Client.DPoPClockSkew),
+                nameof(Entities.Client.DPoPValidationMode),
+                nameof(Entities.Client.RequireDPoP),
+                nameof(Entities.Client.PushedAuthorizationLifetime),
+                nameof(Entities.Client.RequirePushedAuthorization))
+            .Verify(model => model.ToEntity());
+    }
+
+    [Fact]
+    public void ToModel_maps_all_properties()
+    {
+        new MappingVerifier<Entities.Client, Client>()
+            .ExcludeDestinationProperties(
+                // Compatibility properties intentionally not mapped
+                nameof(Client.CibaLifetime),
+                nameof(Client.PollingInterval),
+                nameof(Client.CoordinateLifetimeWithUserSession),
+                nameof(Client.InitiateLoginUri),
+                nameof(Client.DPoPClockSkew),
+                nameof(Client.DPoPValidationMode),
+                nameof(Client.RequireDPoP),
+                nameof(Client.PushedAuthorizationLifetime),
+                nameof(Client.RequirePushedAuthorization))
+            .Verify(entity => entity.ToModel());
+    }
 }

--- a/src/EntityFramework.Storage/test/UnitTests/Mappers/IdentityResourcesMappersTests.cs
+++ b/src/EntityFramework.Storage/test/UnitTests/Mappers/IdentityResourcesMappersTests.cs
@@ -22,4 +22,24 @@ public class IdentityResourcesMappersTests
         Assert.NotNull(mappedModel);
         Assert.NotNull(mappedEntity);
     }
+
+    [Fact]
+    public void ToEntity_maps_all_properties()
+    {
+        new MappingVerifier<IdentityResource, Entities.IdentityResource>()
+            .ExcludeDestinationProperties(
+                // Database-assigned or entity-managed fields not sourced from the model
+                nameof(Entities.IdentityResource.Id),
+                nameof(Entities.IdentityResource.Created),
+                nameof(Entities.IdentityResource.Updated),
+                nameof(Entities.IdentityResource.NonEditable))
+            .Verify(model => model.ToEntity());
+    }
+
+    [Fact]
+    public void ToModel_maps_all_properties()
+    {
+        new MappingVerifier<Entities.IdentityResource, IdentityResource>()
+            .Verify(entity => entity.ToModel());
+    }
 }

--- a/src/EntityFramework.Storage/test/UnitTests/Mappers/MappingVerifier.cs
+++ b/src/EntityFramework.Storage/test/UnitTests/Mappers/MappingVerifier.cs
@@ -1,0 +1,241 @@
+// Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using AwesomeAssertions;
+
+namespace Open.IdentityServer.EntityFramework.UnitTests.Mappers;
+
+/// <summary>
+/// Reflection-based helper that verifies all properties on a destination type are
+/// populated by a mapping function, without maintaining explicit per-property assertions.
+/// <para>
+/// It works by creating both a default and a fully-populated source instance, mapping
+/// each, and asserting that every non-excluded destination property differs between
+/// the two results. A property that is the same in both results was not mapped.
+/// </para>
+/// </summary>
+internal sealed class MappingVerifier<TSource, TDest>
+    where TSource : new()
+    where TDest : new()
+{
+    private readonly HashSet<string> _excludedDestProperties = [];
+    private readonly List<Action<TSource>> _customPopulators = [];
+
+    /// <summary>
+    /// Excludes the specified destination properties from the mapping check.
+    /// Use this for properties intentionally not mapped, e.g. database-assigned keys,
+    /// audit timestamps, and compatibility properties.
+    /// </summary>
+    public MappingVerifier<TSource, TDest> ExcludeDestinationProperties(params string[] properties)
+    {
+        foreach (var p in properties)
+            _excludedDestProperties.Add(p);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a custom action that runs after the generic reflection-based population.
+    /// Use this for source properties whose types reflection cannot handle generically,
+    /// such as collections of types without parameterless constructors.
+    /// </summary>
+    public MappingVerifier<TSource, TDest> WithCustomPopulator(Action<TSource> populator)
+    {
+        _customPopulators.Add(populator);
+        return this;
+    }
+
+    /// <summary>
+    /// Verifies the mapping. Populates a source instance with non-default test values,
+    /// maps it alongside a default source, then asserts that every non-excluded
+    /// destination property differs between the two mapped results.
+    /// </summary>
+    public void Verify(Func<TSource, TDest> mapper)
+    {
+        var defaultSource = new TSource();
+        var populatedSource = new TSource();
+        PopulateWithTestValues(populatedSource, defaultSource);
+        foreach (var populator in _customPopulators)
+            populator(populatedSource);
+
+        var defaultDest = mapper(defaultSource);
+        var populatedDest = mapper(populatedSource);
+
+        var notMapped = typeof(TDest)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanRead && !_excludedDestProperties.Contains(p.Name))
+            .Where(p => AreEquivalent(p.GetValue(defaultDest), p.GetValue(populatedDest)))
+            .Select(p => p.Name)
+            .ToList();
+
+        notMapped.Should().BeEmpty(
+            $"because these destination properties appear not to be mapped from the source: " +
+            $"{string.Join(", ", notMapped)}");
+    }
+
+    /// <summary>
+    /// Populates each property of <paramref name="target"/> with a non-default test value,
+    /// using <paramref name="defaults"/> to determine what the default value is.
+    /// </summary>
+    private static void PopulateWithTestValues(object target, object defaults)
+    {
+        foreach (var prop in target.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (!prop.CanRead) continue;
+            try
+            {
+                var defaultValue = prop.GetValue(defaults);
+                var targetValue = prop.GetValue(target);
+                ApplyTestValue(prop, target, targetValue, defaultValue);
+            }
+            catch
+            {
+                // Skip properties that cannot be safely read or written
+            }
+        }
+    }
+
+    private static void ApplyTestValue(PropertyInfo prop, object target, object? targetValue, object? defaultValue)
+    {
+        var type = prop.PropertyType;
+
+        // Mutable string-keyed dictionary: add a test entry
+        if (targetValue is IDictionary<string, string> dict)
+        {
+            dict[$"test_key_{prop.Name}"] = $"test_val_{prop.Name}";
+            return;
+        }
+
+        // Mutable string collection: add a test item
+        if (targetValue is ICollection<string> strColl)
+        {
+            strColl.Add($"test_{prop.Name}");
+            return;
+        }
+
+        // Collection of complex types with a parameterless constructor
+        if (TryGetCollectionItemType(type, out var itemType) && itemType!.IsClass && itemType != typeof(string))
+        {
+            if (itemType.GetConstructor(Type.EmptyTypes) is not null)
+            {
+                var item = Activator.CreateInstance(itemType)!;
+                PopulateSimpleProperties(item);
+
+                if (targetValue is not null)
+                {
+                    // Try to add to the existing collection via reflection
+                    var addMethod = targetValue.GetType().GetMethod("Add", [itemType]);
+                    if (addMethod is not null)
+                    {
+                        addMethod.Invoke(targetValue, [item]);
+                        return;
+                    }
+                }
+
+                // Collection is null or has no Add method: create a new List<T> and assign it
+                if (prop.CanWrite)
+                {
+                    var newList = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(itemType))!;
+                    newList.Add(item);
+                    prop.SetValue(target, newList);
+                }
+                return;
+            }
+        }
+
+        // Scalar types: compute a new value and assign
+        if (!prop.CanWrite) return;
+        var newValue = ComputeScalarTestValue(type, prop.Name, defaultValue);
+        if (newValue is not null)
+            prop.SetValue(target, newValue);
+    }
+
+    private static object? ComputeScalarTestValue(Type type, string name, object? defaultValue)
+    {
+        if (type == typeof(bool))
+            return !(bool)(defaultValue ?? false);
+
+        if (type == typeof(int))
+            return (int)(defaultValue ?? 0) + 1000;
+
+        if (type == typeof(int?))
+            return (defaultValue as int? ?? 0) + 1000;
+
+        if (type == typeof(string))
+            return $"test_{name}";
+
+        if (type == typeof(DateTime))
+            return DateTime.UtcNow.AddYears(10);
+
+        if (type == typeof(DateTime?))
+            return (DateTime?)DateTime.UtcNow.AddYears(10);
+
+        if (type == typeof(TimeSpan))
+            return TimeSpan.FromHours(99);
+
+        if (type == typeof(TimeSpan?))
+            return (TimeSpan?)TimeSpan.FromHours(99);
+
+        if (type.IsEnum)
+        {
+            var values = Enum.GetValues(type).Cast<object>().ToList();
+            return values.FirstOrDefault(v => !v.Equals(defaultValue)) ?? defaultValue;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Sets primitive-typed properties on <paramref name="item"/> to test values.
+    /// Used when creating instances of complex collection item types.
+    /// </summary>
+    private static void PopulateSimpleProperties(object item)
+    {
+        foreach (var prop in item.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (!prop.CanWrite) continue;
+            try
+            {
+                if (prop.PropertyType == typeof(string))
+                    prop.SetValue(item, $"test_{prop.Name}");
+                else if (prop.PropertyType == typeof(int))
+                    prop.SetValue(item, 99);
+                else if (prop.PropertyType == typeof(bool))
+                    prop.SetValue(item, true);
+            }
+            catch { /* skip */ }
+        }
+    }
+
+    private static bool TryGetCollectionItemType(
+        Type type,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Type? itemType)
+    {
+        itemType = null;
+        if (!type.IsGenericType) return false;
+        var def = type.GetGenericTypeDefinition();
+        if (def != typeof(ICollection<>) && def != typeof(HashSet<>) && def != typeof(List<>)) return false;
+        itemType = type.GetGenericArguments()[0];
+        return true;
+    }
+
+    private static bool AreEquivalent(object? a, object? b)
+    {
+        if (a is null && b is null) return true;
+        if (a is null || b is null) return false;
+
+        // Compare collections by item count
+        if (a is IEnumerable enumA && a is not string)
+        {
+            var countA = enumA.Cast<object>().Count();
+            var countB = (b as IEnumerable)?.Cast<object>().Count() ?? -1;
+            return countA == countB;
+        }
+
+        return a.Equals(b);
+    }
+}

--- a/src/EntityFramework.Storage/test/UnitTests/Mappers/PersistedGrantMappersTests.cs
+++ b/src/EntityFramework.Storage/test/UnitTests/Mappers/PersistedGrantMappersTests.cs
@@ -30,4 +30,21 @@ public class PersistedGrantMappersTests
         mappedModel.ConsumedTime.Should().NotBeNull();
         mappedModel.ConsumedTime.Value.Should().Be(new System.DateTime(2020, 02, 03, 4, 5, 6));
     }
+
+    [Fact]
+    public void ToEntity_maps_all_properties()
+    {
+        new MappingVerifier<PersistedGrant, Entities.PersistedGrant>()
+            .ExcludeDestinationProperties(
+                // Database-assigned or entity-managed fields not sourced from the model
+                nameof(Entities.PersistedGrant.Id))
+            .Verify(model => model.ToEntity());
+    }
+
+    [Fact]
+    public void ToModel_maps_all_properties()
+    {
+        new MappingVerifier<Entities.PersistedGrant, PersistedGrant>()
+            .Verify(entity => entity.ToModel());
+    }
 }

--- a/src/EntityFramework.Storage/test/UnitTests/Mappers/ScopeMappersTests.cs
+++ b/src/EntityFramework.Storage/test/UnitTests/Mappers/ScopeMappersTests.cs
@@ -65,4 +65,25 @@ public class ScopesMappersTests
         mappedModel.Properties["x"].Should().Be("xx");
         mappedModel.Properties["y"].Should().Be("yy");
     }
+
+    [Fact]
+    public void ToEntity_maps_all_properties()
+    {
+        new MappingVerifier<ApiScope, Entities.ApiScope>()
+            .ExcludeDestinationProperties(
+                // Database-assigned or entity-managed fields not sourced from the model
+                nameof(Entities.ApiScope.Id),
+                nameof(Entities.ApiScope.Created),
+                nameof(Entities.ApiScope.Updated),
+                nameof(Entities.ApiScope.LastAccessed),
+                nameof(Entities.ApiScope.NonEditable))
+            .Verify(model => model.ToEntity());
+    }
+
+    [Fact]
+    public void ToModel_maps_all_properties()
+    {
+        new MappingVerifier<Entities.ApiScope, ApiScope>()
+            .Verify(entity => entity.ToModel());
+    }
 }

--- a/src/Open.IdentityServer/src/Configuration/CryptoHelper.cs
+++ b/src/Open.IdentityServer/src/Configuration/CryptoHelper.cs
@@ -123,7 +123,7 @@ public static class CryptoHelper
     /// <param name="algorithm">The algorithm to get the curve name for.</param>
     /// <returns>The name of the curve corresponding to the algorithm.</returns>
     /// <exception cref="NotSupportedException"></exception>
-    public static string? GetCurveNameForAlgorithm(this string algorithm)
+    public static string GetCurveNameForAlgorithm(this string algorithm)
     {
         return algorithm switch
         {

--- a/src/Open.IdentityServer/src/Configuration/CryptoHelper.cs
+++ b/src/Open.IdentityServer/src/Configuration/CryptoHelper.cs
@@ -129,7 +129,7 @@ public static class CryptoHelper
         {
             "ES256" => "P-256",
             "ES384" => "P-384",
-            "ES512" => "P-521",
+            "ES521" => "P-521",
             _ => throw new ArgumentOutOfRangeException(nameof(algorithm), "Unexpected algorithm value for EC Curve")
         };
     }

--- a/src/Open.IdentityServer/src/Configuration/CryptoHelper.cs
+++ b/src/Open.IdentityServer/src/Configuration/CryptoHelper.cs
@@ -98,6 +98,43 @@ public static class CryptoHelper
     }
 
     /// <summary>
+    /// Returns <see langword="true"/> if the algorithm is an RSA algorithm (RSxxx or PSxxx)
+    /// </summary>
+    /// <param name="algorithm">The algorithm to check.</param>
+    /// <returns><see langword="true"/> if the algorithm is an RSA algorithm; otherwise, <see langword="false"/>.</returns>
+    public static bool IsRsaAlgorithm(this string algorithm)
+    {
+        return algorithm.StartsWith('R') || algorithm.StartsWith('P');
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the algorithm is an EC algorithm (Exxx)
+    /// </summary>
+    /// <param name="algorithm">The algorithm to check.</param>
+    /// <returns><see langword="true"/> if the algorithm is an EC algorithm; otherwise, <see langword="false"/>.</returns>
+    public static bool IsEcAlgorithm(this string algorithm)
+    {
+        return algorithm.StartsWith('E');
+    }
+
+    /// <summary>
+    /// Returns the matching named curve for a given algorithm
+    /// </summary>
+    /// <param name="algorithm">The algorithm to get the curve name for.</param>
+    /// <returns>The name of the curve corresponding to the algorithm.</returns>
+    /// <exception cref="NotSupportedException"></exception>
+    public static string? GetCurveNameForAlgorithm(this string algorithm)
+    {
+        return algorithm switch
+        {
+            "ES256" => "P-256",
+            "ES384" => "P-384",
+            "ES512" => "P-521",
+            _ => throw new ArgumentOutOfRangeException(nameof(algorithm), "Unexpected algorithm value for EC Curve")
+        };
+    }
+
+    /// <summary>
     /// Returns the matching named curve for RFC 7518 crv value
     /// </summary>
     internal static ECCurve GetCurveFromCrvValue(string crv)

--- a/src/Open.IdentityServer/src/DataProtection/DataProtectedIdentityServerKeyMaterialConverter.cs
+++ b/src/Open.IdentityServer/src/DataProtection/DataProtectedIdentityServerKeyMaterialConverter.cs
@@ -45,8 +45,7 @@ public class DataProtectedIdentityServerKeyMaterialConverter(IDataProtectionProv
             dataProtector.Unprotect(keyMaterial.Data) : 
             keyMaterial.Data;
 
-        if (!keyMaterial.IsX509Certificate &&
-            (keyMaterial.Algorithm.StartsWith('R') || keyMaterial.Algorithm.StartsWith('P')))
+        if (!keyMaterial.IsX509Certificate && keyMaterial.Algorithm.IsRsaAlgorithm())
         {
             var keyData = JsonSerializer.Deserialize<RsaIdentityServerKeyData>(unprotectedData, Settings);
 
@@ -54,18 +53,12 @@ public class DataProtectedIdentityServerKeyMaterialConverter(IDataProtectionProv
             signingKey.Credentials = new SigningCredentials(new RsaSecurityKey(keyData.Parameters) { KeyId = keyData.Id }, keyData.Algorithm);
         }
         
-        if (!keyMaterial.IsX509Certificate && keyMaterial.Algorithm.StartsWith('E'))
+        if (!keyMaterial.IsX509Certificate && keyMaterial.Algorithm.IsEcAlgorithm())
         {
             var keyData = JsonSerializer.Deserialize<EcIdentityServerKeyData>(unprotectedData, Settings);
 
-            ECCurve curve = keyMaterial.Algorithm switch
-            {
-                "ES256" => CryptoHelper.GetCurveFromCrvValue("P-256"),
-                "ES384" => CryptoHelper.GetCurveFromCrvValue("P-384"),
-                "ES521" => CryptoHelper.GetCurveFromCrvValue("P-521"),
-                _ => throw new ArgumentOutOfRangeException(nameof(keyMaterial.Algorithm), "Unexpected algorithm value for EC Curve")
-            };
-
+            ECCurve curve = CryptoHelper.GetCurveFromCrvValue(
+                keyMaterial.Algorithm.GetCurveNameForAlgorithm());
             var ecdsa = ECDsa.Create(new ECParameters { Curve = curve, D = keyData.D, Q = keyData.Q });
             
             signingKey.Created = keyData.Created;

--- a/src/Open.IdentityServer/src/Extensions/StringsExtensions.cs
+++ b/src/Open.IdentityServer/src/Extensions/StringsExtensions.cs
@@ -7,9 +7,12 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Text.Encodings.Web;
+
+#nullable enable
 
 namespace Open.IdentityServer.Extensions;
 
@@ -47,7 +50,7 @@ internal static class StringExtensions
         return input.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).ToList();
     }
 
-    public static List<string> ParseScopesString(this string scopes)
+    public static List<string>? ParseScopesString(this string? scopes)
     {
         if (scopes.IsMissing())
         {
@@ -67,13 +70,13 @@ internal static class StringExtensions
     }
 
     [DebuggerStepThrough]
-    public static bool IsMissing(this string value)
+    public static bool IsMissing([NotNullWhen(false)] this string? value)
     {
         return string.IsNullOrWhiteSpace(value);
     }
 
     [DebuggerStepThrough]
-    public static bool IsMissingOrTooLong(this string value, int maxLength)
+    public static bool IsMissingOrTooLong(this string? value, int maxLength)
     {
         if (string.IsNullOrWhiteSpace(value))
         {
@@ -89,13 +92,13 @@ internal static class StringExtensions
     }
 
     [DebuggerStepThrough]
-    public static bool IsPresent(this string value)
+    public static bool IsPresent([NotNullWhen(true)] this string? value)
     {
         return !string.IsNullOrWhiteSpace(value);
     }
 
     [DebuggerStepThrough]
-    public static string EnsureLeadingSlash(this string url)
+    public static string? EnsureLeadingSlash(this string? url)
     {
         if (url != null && !url.StartsWith("/"))
         {
@@ -106,7 +109,7 @@ internal static class StringExtensions
     }
 
     [DebuggerStepThrough]
-    public static string EnsureTrailingSlash(this string url)
+    public static string? EnsureTrailingSlash(this string? url)
     {
         if (url != null && !url.EndsWith("/"))
         {
@@ -117,7 +120,7 @@ internal static class StringExtensions
     }
 
     [DebuggerStepThrough]
-    public static string RemoveLeadingSlash(this string url)
+    public static string? RemoveLeadingSlash(this string? url)
     {
         if (url != null && url.StartsWith("/"))
         {
@@ -128,7 +131,7 @@ internal static class StringExtensions
     }
 
     [DebuggerStepThrough]
-    public static string RemoveTrailingSlash(this string url)
+    public static string? RemoveTrailingSlash(this string? url)
     {
         if (url != null && url.EndsWith("/"))
         {
@@ -139,9 +142,9 @@ internal static class StringExtensions
     }
 
     [DebuggerStepThrough]
-    public static string CleanUrlPath(this string url)
+    public static string CleanUrlPath(this string? url)
     {
-        if (String.IsNullOrWhiteSpace(url)) url = "/";
+        if (string.IsNullOrWhiteSpace(url)) url = "/";
 
         if (url != "/" && url.EndsWith("/"))
         {
@@ -153,7 +156,7 @@ internal static class StringExtensions
 
     [DebuggerStepThrough]
     // Clone of UrlHelperBase.CheckIsLocalUrl from https://github.com/dotnet/aspnetcore/blob/3f1acb59718cadf111a0a796681e3d3509bb3381/src/Mvc/Mvc.Core/src/Routing/UrlHelperBase.cs
-    public static bool IsLocalUrl(this string url)
+    public static bool IsLocalUrl(this string? url)
     {
         if (string.IsNullOrEmpty(url))
         {
@@ -246,7 +249,7 @@ internal static class StringExtensions
     }
 
     [DebuggerStepThrough]
-    public static NameValueCollection ReadQueryStringAsNameValueCollection(this string url)
+    public static NameValueCollection ReadQueryStringAsNameValueCollection(this string? url)
     {
         if (url != null)
         {
@@ -266,7 +269,7 @@ internal static class StringExtensions
         return new NameValueCollection();
     }
 
-    public static string GetOrigin(this string url)
+    public static string? GetOrigin(this string? url)
     {
         if (url != null)
         {

--- a/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Utility/InternalStringExtensions.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.IntegrationTests/Utility/InternalStringExtensions.cs
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Modified by Rock Solid Knowledge Ltd. Copyright in modifications 2026, Rock Solid Knowledge Ltd.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 #nullable enable
 
@@ -11,13 +12,13 @@ namespace IdentityServer.IntegrationTests.Utility;
 internal static class InternalStringExtensions
 {
     [DebuggerStepThrough]
-    public static bool IsMissing(this string value)
+    public static bool IsMissing([NotNullWhen(false)] this string? value)
     {
         return string.IsNullOrWhiteSpace(value);
     }
 
     [DebuggerStepThrough]
-    public static bool IsPresent(this string value)
+    public static bool IsPresent([NotNullWhen(true)] this string? value)
     {
         return !(value.IsMissing());
     }

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Configuration/CryptoHelperTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Configuration/CryptoHelperTests.cs
@@ -33,7 +33,7 @@ public class CryptoHelperTests
     [Theory]
     [InlineData("ES256")]
     [InlineData("ES384")]
-    [InlineData("ES512")]
+    [InlineData("ES521")]
     public void IsEcAlgorithm_ShouldReturnTrueForEcAlgorithms(string algorithm)
     {
         algorithm.IsEcAlgorithm().Should().BeTrue();
@@ -56,7 +56,7 @@ public class CryptoHelperTests
     [Theory]
     [InlineData("ES256", "P-256")]
     [InlineData("ES384", "P-384")]
-    [InlineData("ES512", "P-521")]
+    [InlineData("ES521", "P-521")]
     public void GetCurveNameForAlgorithm_ShouldReturnCorrectCurveNameForEcAlgorithms(string algorithm, string expectedCurveName)
     {
         algorithm.GetCurveNameForAlgorithm().Should().Be(expectedCurveName);

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Configuration/CryptoHelperTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Configuration/CryptoHelperTests.cs
@@ -1,0 +1,79 @@
+﻿using AwesomeAssertions;
+using Open.IdentityServer.Configuration;
+using System;
+using Xunit;
+
+namespace Open.IdentityServer.UnitTests.Configuration;
+
+public class CryptoHelperTests
+{
+    [Theory]
+    [InlineData("RS256")]
+    [InlineData("RS384")]
+    [InlineData("RS512")]
+    [InlineData("PS256")]
+    [InlineData("PS384")]
+    [InlineData("PS512")]
+    public void IsRsaAlgorithm_ShouldReturnTrueForRsaAlgorithms(string algorithm)
+    {
+        algorithm.IsRsaAlgorithm().Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("ES256")]
+    [InlineData("ES384")]
+    [InlineData("ES512")]
+    [InlineData("HS256")]
+    [InlineData("AES256")]
+    public void IsRsaAlgorithm_ShouldReturnFalseForNonRsaAlgorithms(string algorithm)
+    {
+        algorithm.IsRsaAlgorithm().Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("ES256")]
+    [InlineData("ES384")]
+    [InlineData("ES512")]
+    public void IsEcAlgorithm_ShouldReturnTrueForEcAlgorithms(string algorithm)
+    {
+        algorithm.IsEcAlgorithm().Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("RS256")]
+    [InlineData("RS384")]
+    [InlineData("RS512")]
+    [InlineData("PS256")]
+    [InlineData("PS384")]
+    [InlineData("PS512")]
+    [InlineData("HS256")]
+    [InlineData("AES256")]
+    public void IsEcAlgorithm_ShouldReturnFalseForNonEcAlgorithms(string algorithm)
+    {
+        algorithm.IsEcAlgorithm().Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("ES256", "P-256")]
+    [InlineData("ES384", "P-384")]
+    [InlineData("ES512", "P-521")]
+    public void GetCurveNameForAlgorithm_ShouldReturnCorrectCurveNameForEcAlgorithms(string algorithm, string expectedCurveName)
+    {
+        algorithm.GetCurveNameForAlgorithm().Should().Be(expectedCurveName);
+    }
+
+    [Theory]
+    [InlineData("RS256")]
+    [InlineData("RS384")]
+    [InlineData("RS512")]
+    [InlineData("PS256")]
+    [InlineData("PS384")]
+    [InlineData("PS512")]
+    [InlineData("HS256")]
+    [InlineData("AES256")]
+    public void GetCurveNameForAlgorithm_ShouldThrowArgumentOutOfRangeExceptionForNonEcAlgorithms(string algorithm)
+    {
+        Action act = () => algorithm.GetCurveNameForAlgorithm();
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Open.IdentityServer.UnitTests.csproj
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Open.IdentityServer.UnitTests.csproj
@@ -12,18 +12,18 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
 
-        <PackageReference Include="xunit.v3"/>
-        <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All"/>
-        <PackageReference Include="AwesomeAssertions"/>
-        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing"/>
-        <PackageReference Include="Moq"/>
+        <PackageReference Include="xunit.v3" />
+        <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
+        <PackageReference Include="AwesomeAssertions" />
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+        <PackageReference Include="Moq" />
     </ItemGroup>
 
     <ItemGroup>
@@ -36,6 +36,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Open.IdentityServer.csproj"/>
+        <ProjectReference Include="..\..\src\Open.IdentityServer.csproj" />
     </ItemGroup>
 </Project>

--- a/src/Storage/src/Extensions/StringsExtensions.cs
+++ b/src/Storage/src/Extensions/StringsExtensions.cs
@@ -1,21 +1,25 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Modified by Rock Solid Knowledge Ltd. Copyright in modifications 2026, Rock Solid Knowledge Ltd.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+#nullable enable
 
 namespace Open.IdentityServer.Extensions;
 
 internal static class StringExtensions
 {
     [DebuggerStepThrough]
-    public static bool IsMissing(this string value)
+    public static bool IsMissing([NotNullWhen(false)] this string? value)
     {
         return string.IsNullOrWhiteSpace(value);
     }
 
     [DebuggerStepThrough]
-    public static bool IsPresent(this string value)
+    public static bool IsPresent([NotNullWhen(true)] this string? value)
     {
         return !string.IsNullOrWhiteSpace(value);
     }


### PR DESCRIPTION
## Description

I added a generic (using reflection) helper to verify that all properties are mapped to/from entity/model. I choose to not modify the existing tests that exists for some of the entities/models.
It caught a missing property for Client.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation
- [x] Other

## Does this PR introduce a breaking change?

_Does the change cause existing functionality to not work as previously expected, or does the DB schema or C# public API surface change?_

- [ ] Yes
- [x] No

## Testing

The change is additional tests. I choose to not change or remove the existing mapping tests, even though some of them are redundant now.

## LLM Usage

I used co-pilot to create the MappingVerifier class.

## Other context