### PR TITLE
Referencetoken should include iat claim

### DIFF
--- a/src/Open.IdentityServer/src/Validation/Default/TokenValidator.cs
+++ b/src/Open.IdentityServer/src/Validation/Default/TokenValidator.cs
@@ -405,13 +405,14 @@ internal class TokenValidator : ITokenValidator
             new Claim(JwtClaimTypes.IssuedAt, new DateTimeOffset(token.CreationTime).ToUnixTimeSeconds().ToString(), ClaimValueTypes.Integer64),
             new Claim(JwtClaimTypes.Expiration, new DateTimeOffset(token.CreationTime).AddSeconds(token.Lifetime).ToUnixTimeSeconds().ToString(), ClaimValueTypes.Integer64)
         };
+        var ignoreClaimTypes = claims.Select(c => c.Type).ToArray();
 
         foreach (var aud in token.Audiences)
         {
             claims.Add(new Claim(JwtClaimTypes.Audience, aud));
         }
 
-        claims.AddRange(token.Claims);
+        claims.AddRange(token.Claims.Where(c => !ignoreClaimTypes.Contains(c.Type)));
         return claims;
     }
 

--- a/src/Open.IdentityServer/src/Validation/Default/TokenValidator.cs
+++ b/src/Open.IdentityServer/src/Validation/Default/TokenValidator.cs
@@ -402,6 +402,7 @@ internal class TokenValidator : ITokenValidator
         {
             new Claim(JwtClaimTypes.Issuer, token.Issuer),
             new Claim(JwtClaimTypes.NotBefore, new DateTimeOffset(token.CreationTime).ToUnixTimeSeconds().ToString(), ClaimValueTypes.Integer64),
+            new Claim(JwtClaimTypes.IssuedAt, new DateTimeOffset(token.CreationTime).ToUnixTimeSeconds().ToString(), ClaimValueTypes.Integer64),
             new Claim(JwtClaimTypes.Expiration, new DateTimeOffset(token.CreationTime).AddSeconds(token.Lifetime).ToUnixTimeSeconds().ToString(), ClaimValueTypes.Integer64)
         };
 

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Validation/AccessTokenValidation.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Validation/AccessTokenValidation.cs
@@ -62,7 +62,7 @@ public class AccessTokenValidation
         var result = await validator.ValidateAccessTokenAsync(handle);
 
         result.IsError.Should().BeFalse();
-        result.Claims.Count().Should().Be(8);
+        result.Claims.Count().Should().Be(9);
         result.Claims.First(c => c.Type == JwtClaimTypes.ClientId).Value.Should().Be("roclient");
     }
 

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Validation/AccessTokenValidation.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Validation/AccessTokenValidation.cs
@@ -3,19 +3,19 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using System;
-using System.IdentityModel.Tokens.Jwt;
-using System.Linq;
-using System.Threading.Tasks;
 using AwesomeAssertions;
 using Moq;
-using Open.IdentityServer.UnitTests.Common;
-using Open.IdentityServer.UnitTests.Validation.Setup;
-using Open.IdentityServer;
 using Open.IdentityServer.Configuration;
 using Open.IdentityServer.Models;
 using Open.IdentityServer.Services;
 using Open.IdentityServer.Stores;
+using Open.IdentityServer.UnitTests.Common;
+using Open.IdentityServer.UnitTests.Validation.Setup;
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Open.IdentityServer.UnitTests.Validation;
@@ -80,6 +80,29 @@ public class AccessTokenValidation
         var result = await validator.ValidateAccessTokenAsync(handle, "read");
 
         result.IsError.Should().BeFalse();
+    }
+
+    [Theory()]
+    [InlineData(JwtClaimTypes.Issuer)]
+    [InlineData(JwtClaimTypes.NotBefore)]
+    [InlineData(JwtClaimTypes.IssuedAt)]
+    [InlineData(JwtClaimTypes.Expiration)]
+    [Trait("Category", Category)]
+    public async Task Valid_Reference_Token_with_protocol_claims_should_not_be_duplicated(string claimType)
+    {
+        var store = Factory.CreateReferenceTokenStore();
+        var validator = Factory.CreateTokenValidator(store);
+
+        var token = TokenFactory.CreateAccessToken(new Client { ClientId = "roclient" }, "valid", 600, "read", "write");
+        var protocolClaim = new Claim(claimType, "value");
+        token.Claims.Add(protocolClaim);
+
+        var handle = await store.StoreReferenceTokenAsync(token);
+
+        var result = await validator.ValidateAccessTokenAsync(handle);
+
+        result.IsError.Should().BeFalse();
+        result.Claims.Should().NotContain(c => c.Type == protocolClaim.Type && c.Value == protocolClaim.Value);
     }
 
     [Fact]

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Validation/IntrospectionRequestValidatorTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Validation/IntrospectionRequestValidatorTests.cs
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Modified by Rock Solid Knowledge Ltd. Copyright in modifications 2026, Rock Solid Knowledge Ltd.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Validation/IntrospectionRequestValidatorTests.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Validation/IntrospectionRequestValidatorTests.cs
@@ -57,8 +57,15 @@ public class IntrospectionRequestValidatorTests
 
         result.IsError.Should().Be(false);
         result.IsActive.Should().Be(true);
-        result.Claims.Count().Should().Be(5);
+        result.Claims.Count().Should().Be(6);
         result.Token.Should().Be(handle);
+
+        var claimTypes = result.Claims.Select(x => x.Type).ToArray();
+        claimTypes.Should().Contain(JwtClaimTypes.IssuedAt);
+        claimTypes.Should().Contain(JwtClaimTypes.Issuer);
+        claimTypes.Should().Contain(JwtClaimTypes.NotBefore);
+        claimTypes.Should().Contain(JwtClaimTypes.Expiration);
+        claimTypes.Should().Contain(JwtClaimTypes.Scope);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Added iat claim as it is required by RFC9068. Resolves issue https://github.com/RockSolidKnowledge/Open.IdentityServer/issues/60.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Does this PR introduce a breaking change?

_Does the change cause existing functionality to not work as previously expected, or does the DB schema or C# public API surface change?_

- [ ] Yes
- [x] No

## Testing

I have updated the existing unit tests.

## LLM Usage

Not used.

## Other context

_Please include any other contextual information to support this change, if necessary._
_eg. Instructions for testing and validating the code, any necessary dependencies or environmental setup_