### PR TITLE
feat: Added max length restriction to resource indicator.

### DIFF
--- a/src/Open.IdentityServer/src/Configuration/DependencyInjection/Options/InputLengthRestrictions.cs
+++ b/src/Open.IdentityServer/src/Configuration/DependencyInjection/Options/InputLengthRestrictions.cs
@@ -1,4 +1,5 @@
 // Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Modified by Rock Solid Knowledge Ltd. Copyright in modifications 2026, Rock Solid Knowledge Ltd.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -126,4 +127,9 @@ public class InputLengthRestrictions
     /// Max length for the code verifier
     /// </summary>
     public int CodeVerifierMaxLength { get; } = 128;
+
+    /// <summary>
+    /// Max length for resource indicator parameter
+    /// </summary>
+    public int ResourceIndicatorMaxLength { get; } = 400;
 }

--- a/src/Open.IdentityServer/src/Configuration/DependencyInjection/Options/InputLengthRestrictions.cs
+++ b/src/Open.IdentityServer/src/Configuration/DependencyInjection/Options/InputLengthRestrictions.cs
@@ -131,5 +131,5 @@ public class InputLengthRestrictions
     /// <summary>
     /// Max length for resource indicator parameter
     /// </summary>
-    public int ResourceIndicatorMaxLength { get; } = 400;
+    public int ResourceIndicatorMaxLength { get; } = 512;
 }

--- a/src/Open.IdentityServer/src/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/Open.IdentityServer/src/Validation/Default/AuthorizeRequestValidator.cs
@@ -605,6 +605,12 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
         var resources = request.GetResourceIndicators();
         if (resources.Count != 0)
         {
+            if (resources.Any(x => x.Length > _options.InputLengthRestrictions.ResourceIndicatorMaxLength))
+            {
+                return Invalid(request, OidcConstants.AuthorizeErrors.InvalidTarget,
+                    "Resource indicator maximum length exceeded.");
+            }
+
             if (resources.Any(x => x.InValidResourceIndicatorString()))
             {
                 LogError("resource(s) invalid", request);

--- a/src/Open.IdentityServer/src/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/Open.IdentityServer/src/Validation/Default/AuthorizeRequestValidator.cs
@@ -607,6 +607,7 @@ internal class AuthorizeRequestValidator : IAuthorizeRequestValidator
         {
             if (resources.Any(x => x.Length > _options.InputLengthRestrictions.ResourceIndicatorMaxLength))
             {
+                LogError("resource(s) are too long", request);
                 return Invalid(request, OidcConstants.AuthorizeErrors.InvalidTarget,
                     "Resource indicator maximum length exceeded.");
             }

--- a/src/Open.IdentityServer/src/Validation/Default/TokenRequestValidator.cs
+++ b/src/Open.IdentityServer/src/Validation/Default/TokenRequestValidator.cs
@@ -162,6 +162,7 @@ internal class TokenRequestValidator : ITokenRequestValidator
         {
             if (resources.Any(x => x.Length > _options.InputLengthRestrictions.ResourceIndicatorMaxLength))
             {
+                LogError("resource(s) are too long", _validatedRequest); 
                 return Invalid(OidcConstants.AuthorizeErrors.InvalidTarget, 
                     "Resource indicator maximum length exceeded.");
             }

--- a/src/Open.IdentityServer/src/Validation/Default/TokenRequestValidator.cs
+++ b/src/Open.IdentityServer/src/Validation/Default/TokenRequestValidator.cs
@@ -160,6 +160,12 @@ internal class TokenRequestValidator : ITokenRequestValidator
         var resources = _validatedRequest.GetResourceIndicators();
         if (resources.Count != 0)
         {
+            if (resources.Any(x => x.Length > _options.InputLengthRestrictions.ResourceIndicatorMaxLength))
+            {
+                return Invalid(OidcConstants.AuthorizeErrors.InvalidTarget, 
+                    "Resource indicator maximum length exceeded.");
+            }
+
             if (_validatedRequest.GrantType == OidcConstants.GrantTypes.DeviceCode)
             {
                 LogError("resource provided with DeviceCode grant type");

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ResourceIndicators_InValid.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ResourceIndicators_InValid.cs
@@ -1,11 +1,12 @@
 // Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Modified by Rock Solid Knowledge Ltd. Copyright in modifications 2026, Rock Solid Knowledge Ltd.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+using AwesomeAssertions;
+using Open.IdentityServer.Configuration;
+using Open.IdentityServer.UnitTests.Validation.Setup;
 using System.Collections.Specialized;
 using System.Threading.Tasks;
-using AwesomeAssertions;
-using Open.IdentityServer.UnitTests.Validation.Setup;
-using Open.IdentityServer;
 using Xunit;
 
 namespace Open.IdentityServer.UnitTests.Validation.AuthorizeRequest_Validation;
@@ -130,6 +131,26 @@ public class Authorize_ResourceIndicators_InValid
         var validator = Factory.CreateAuthorizeRequestValidator();
         var result = await validator.ValidateAsync(parameters);
 
+        result.IsError.Should().BeTrue();
+        result.Error.Should().Be(OidcConstants.AuthorizeErrors.InvalidTarget);
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
+    public async Task InValid_ResourceIndicators_AreToLong()
+    {
+        var parameters = new NameValueCollection();
+        parameters.Add(OidcConstants.AuthorizeRequest.ClientId, "codeclient");
+        parameters.Add(OidcConstants.AuthorizeRequest.Scope, "openid urn:valid.resource:Read valid:All");
+        parameters.Add(OidcConstants.AuthorizeRequest.RedirectUri, "https://server/cb");
+        parameters.Add(OidcConstants.AuthorizeRequest.ResponseType, OidcConstants.ResponseTypes.Code);
+        parameters.Add(OidcConstants.AuthorizeRequest.ResponseMode, OidcConstants.ResponseModes.Query);
+
+        parameters.Add(OidcConstants.AuthorizeRequest.Resource, "urn:valid.resource." + new string('a', new IdentityServerOptions().InputLengthRestrictions.ResourceIndicatorMaxLength));
+        
+        var validator = Factory.CreateAuthorizeRequestValidator();
+        var result = await validator.ValidateAsync(parameters);
+        
         result.IsError.Should().BeTrue();
         result.Error.Should().Be(OidcConstants.AuthorizeErrors.InvalidTarget);
     }

--- a/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_ResourceIndicators.cs
+++ b/src/Open.IdentityServer/test/Open.IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_ResourceIndicators.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2026, Rock Solid Knowledge Ltd
+// Modified by Rock Solid Knowledge Ltd. Copyright in modifications 2026, Rock Solid Knowledge Ltd.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using System;
@@ -7,10 +8,10 @@ using System.Collections.Specialized;
 using System.Threading.Tasks;
 using AwesomeAssertions;
 using Open.IdentityServer.UnitTests.Validation.Setup;
-using Open.IdentityServer;
 using Open.IdentityServer.Models;
 using Open.IdentityServer.Stores;
 using Xunit;
+using Open.IdentityServer.Configuration;
 
 namespace Open.IdentityServer.UnitTests.Validation.TokenRequest_Validation;
 
@@ -477,6 +478,26 @@ public class TokenRequestValidation_ResourceIndicators
 
     [Fact]
     [Trait("Category", Category)]
+    public async Task Invalid_ClientCredentials_WithResourceIndicatorToLong()
+    {
+        var client = await _clients.FindEnabledClientByIdAsync("client");
+
+        var validator = Factory.CreateTokenRequestValidator();
+
+        var parameters = new NameValueCollection
+        {
+            { OidcConstants.TokenRequest.GrantType, OidcConstants.GrantTypes.ClientCredentials },
+            { OidcConstants.TokenRequest.Scope, "urn:valid.resource:All" },
+            { OidcConstants.TokenRequest.Resource, "urn:valid.resource." + new string('a', new IdentityServerOptions().InputLengthRestrictions.ResourceIndicatorMaxLength) },
+        };
+
+        var result = await validator.ValidateRequestAsync(parameters, client.ToValidationResult());
+
+        result.IsError.Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", Category)]
     public async Task Valid_ClientCredentials_WithResourceIndicator()
     {
         var client = await _clients.FindEnabledClientByIdAsync("client");
@@ -494,7 +515,7 @@ public class TokenRequestValidation_ResourceIndicators
 
         result.IsError.Should().BeFalse();
     }
-        
+
     [Fact]
     [Trait("Category", Category)]
     public async Task Invalid_DeviceCode_WithResourceIndicator()


### PR DESCRIPTION
## Description

Validation of max length for resource indicators. Closes #67 

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Does this PR introduce a breaking change?

_Does the change cause existing functionality to not work as previously expected, or does the DB schema or C# public API surface change?_

- [ ] Yes
- [x] No

## Testing

Added unit tests for Authorize request validator and Token request validator.

## LLM Usage

None

## Other context

None